### PR TITLE
fix: Remove invalid domains key from hacs.json for HACS validation

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,10 +1,6 @@
 {
   "name": "National Rail Commute",
   "render_readme": true,
-  "domains": [
-    "sensor",
-    "binary_sensor"
-  ],
   "homeassistant": "2024.1.0",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
HACS validation does not allow the 'domains' key in hacs.json. This information is already correctly specified in manifest.json.