### PR TITLE
docs: Add Lovelace card link and fix disruption threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A custom Home Assistant integration that tracks regular commutes using National 
 - **Multi-Route Support**: Configure multiple commutes (e.g., morning and evening journeys)
 - **UI Configuration**: Easy setup through Home Assistant's config flow interface
 - **HACS Compatible**: Simple installation via Home Assistant Community Store
-- **Custom Lovelace Card**: Beautiful, dedicated dashboard card for displaying train information
+- **Custom Lovelace Card**: Beautiful, dedicated [dashboard card](https://github.com/adamf83/lovelace-my-rail-commute-card) for displaying train information
 
 ## Sensors
 
@@ -88,7 +88,7 @@ The integration creates multiple sensors for each configured commute:
 - **Trigger Conditions**:
   - Any train cancelled
   - Single train delayed ≥15 minutes
-  - Multiple trains (≥2) delayed ≥5 minutes
+  - Multiple trains (≥2) delayed ≥10 minutes
 
 ## Prerequisites
 


### PR DESCRIPTION
- Add link to lovelace-my-rail-commute-card repo in Features section
- Correct disruption threshold from ≥5 to ≥10 minutes for multiple delayed trains
- Ensures README accurately reflects the actual integration behavior
- Fixes #10 