### PR TITLE
fix: Pass config_entry to NationalRailCommuteOptionsFlow constructor

### DIFF
--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -322,11 +322,19 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Returns:
             Options flow handler
         """
-        return NationalRailCommuteOptionsFlow()
+        return NationalRailCommuteOptionsFlow(config_entry)
 
 
 class NationalRailCommuteOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for My Rail Commute."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow.
+
+        Args:
+            config_entry: Config entry instance
+        """
+        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
The OptionsFlow class needs to receive the config_entry instance in order to access configuration data. This follows the standard Home Assistant pattern for options flows.

Changes:
- Modified async_get_options_flow() to pass config_entry to the constructor
- Added __init__() method to NationalRailCommuteOptionsFlow to accept and store the config_entry parameter

This fixes AttributeError: 'NationalRailCommuteOptionsFlow' object has no attribute 'config_entry' in tests/test_config_flow.py::TestOptionsFlow