### PR TITLE
fix: Add delay after aiohttp session close for Python 3.12 thread cle…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,8 @@ def mock_api_client_fixture() -> Generator[AsyncMock]:
 @pytest.fixture(scope="function")
 async def aiohttp_session() -> AsyncGenerator[aiohttp.ClientSession, None]:
     """Create a real aiohttp session for testing."""
+    import asyncio
+
     # Create a new session for each test
     session = aiohttp.ClientSession()
     try:
@@ -83,6 +85,10 @@ async def aiohttp_session() -> AsyncGenerator[aiohttp.ClientSession, None]:
         # Ensure proper cleanup even if test fails
         if not session.closed:
             await session.close()
+        # Wait for the connector to fully close and background threads to finish
+        # This is necessary in Python 3.12 where aiohttp's _run_safe_shutdown_loop
+        # thread needs time to complete before pytest checks for lingering threads
+        await asyncio.sleep(0.250)
 
 
 def load_fixture(filename: str) -> str:


### PR DESCRIPTION
…anup

In Python 3.12, aiohttp's TCPConnector creates a background thread called _run_safe_shutdown_loop for cleanup. This thread doesn't complete immediately after session.close() is called. The pytest-homeassistant-custom-component plugin checks for lingering threads and fails if non-dummy/waitpid threads remain.

Added a 250ms sleep after closing the session to allow the background thread to complete before thread checking occurs. This is the recommended pattern for aiohttp in test environments.

Fixes the test_init assertion error where the _run_safe_shutdown_loop thread was detected as a lingering thread.