### PR TITLE
feat: Add state-based status sensors for easier automations

### DIFF
--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -50,8 +50,19 @@ DISRUPTION_MULTIPLE_SERVICES: Final = 2
 
 # Sensor types
 SENSOR_SUMMARY: Final = "summary"
+SENSOR_STATUS: Final = "status"
 SENSOR_NEXT_TRAIN: Final = "next_train"
 SENSOR_DISRUPTION: Final = "disruption"
+
+# Commute status levels (for overall commute status sensor)
+STATUS_NORMAL: Final = "Normal"
+STATUS_MINOR_DELAYS: Final = "Minor Delays"
+STATUS_MAJOR_DELAYS: Final = "Major Delays"
+STATUS_CANCELLATIONS: Final = "Cancellations"
+
+# Delay thresholds for commute status classification
+STATUS_MINOR_DELAY_THRESHOLD: Final = 1  # minutes
+STATUS_MAJOR_DELAY_THRESHOLD: Final = 10  # minutes
 
 # Attributes
 ATTR_ORIGIN: Final = "origin"


### PR DESCRIPTION
Adds two new capabilities to simplify automation triggers:

1. Overall Commute Status Sensor (sensor.{name}_status)
   - State values: Normal, Minor Delays, Major Delays, Cancellations
   - No template conditions needed - trigger directly on state changes
   - Includes detailed attributes: counts per category, max delay
   - Dynamic icons based on status level

2. Individual Train Status as State
   - Train sensors now use status as state (On Time, Delayed, Cancelled, Expected)
   - Departure time moved from state to 'departure_time' attribute
   - Enables simple triggers like: to: "Delayed" instead of template conditions
   - Applies to both next_train and individual train_X sensors

Benefits:
- Much simpler automations - no complex template conditions needed
- State-based triggers are more reliable and easier to understand
- Addresses user feedback about difficulty triggering on status changes
- Maintains backward compatibility via attributes

Updated documentation with new automation examples demonstrating the simpler state-based approach.