### PR TITLE
fix: Add user-friendly labels for disruption threshold fields in tran…

### DIFF
--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -23,6 +23,9 @@
           "commute_name": "Commute Name",
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
+          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
+          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
+          "disruption_multiple_count": "Number of Trains for Alert",
           "night_updates": "Enable Night-Time Updates"
         }
       }
@@ -46,6 +49,9 @@
         "data": {
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
+          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
+          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
+          "disruption_multiple_count": "Number of Trains for Alert",
           "night_updates": "Enable Night-Time Updates"
         }
       }


### PR DESCRIPTION
…slations

The disruption threshold configuration fields (disruption_single_delay, disruption_multiple_delay, and disruption_multiple_count) were showing their internal field names with underscores instead of user-friendly labels.

This was because the translations/en.json file was missing the label definitions for these fields in both the config and options sections. Added proper labels:
- "Single Train Delay Threshold (minutes)"
- "Multiple Trains Delay Threshold (minutes)"
- "Number of Trains for Alert"