### PR TITLE
fix: Ensure strings.json matches translations for disruption threshol…

### DIFF
--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -23,8 +23,8 @@
           "commute_name": "Commute Name",
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
-          "disruption_single_delay": "Single Train Delay Threshold",
-          "disruption_multiple_delay": "Multiple Trains Delay Threshold",
+          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
+          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
           "disruption_multiple_count": "Number of Trains for Alert",
           "night_updates": "Enable Night-Time Updates"
         }
@@ -49,8 +49,8 @@
         "data": {
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
-          "disruption_single_delay": "Single Train Delay Threshold",
-          "disruption_multiple_delay": "Multiple Trains Delay Threshold",
+          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
+          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
           "disruption_multiple_count": "Number of Trains for Alert",
           "night_updates": "Enable Night-Time Updates"
         }


### PR DESCRIPTION
…d labels

Updated strings.json to include "(minutes)" suffix for disruption threshold fields to match translations/en.json. This ensures labels display correctly in the UI instead of showing raw field names with underscores.