### PR TITLE
refactor: Redesign status, summary, and disruption sensors for clarity

### DIFF
--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -63,15 +63,17 @@ SENSOR_STATUS: Final = "status"
 SENSOR_NEXT_TRAIN: Final = "next_train"
 SENSOR_DISRUPTION: Final = "disruption"
 
-# Commute status levels (for overall commute status sensor)
+# Commute status levels (unified hierarchy for all sensors)
 STATUS_NORMAL: Final = "Normal"
 STATUS_MINOR_DELAYS: Final = "Minor Delays"
 STATUS_MAJOR_DELAYS: Final = "Major Delays"
-STATUS_CANCELLATIONS: Final = "Cancellations"
+STATUS_SEVERE_DISRUPTION: Final = "Severe Disruption"
+STATUS_CRITICAL: Final = "Critical"
 
-# Delay thresholds for commute status classification
+# Delay thresholds for status classification
 STATUS_MINOR_DELAY_THRESHOLD: Final = 1  # minutes
 STATUS_MAJOR_DELAY_THRESHOLD: Final = 10  # minutes
+# Severe and Critical levels use user-configurable disruption thresholds
 
 # Attributes
 ATTR_ORIGIN: Final = "origin"

--- a/custom_components/my_rail_commute/manifest.json
+++ b/custom_components/my_rail_commute/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "aiohttp>=3.9.0"
   ],
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -23,9 +23,9 @@
           "commute_name": "Commute Name",
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
-          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
-          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
-          "disruption_multiple_count": "Number of Trains for Alert",
+          "disruption_single_delay": "Severe Disruption Threshold - Single Train (minutes)",
+          "disruption_multiple_delay": "Severe Disruption Threshold - Multiple Trains (minutes)",
+          "disruption_multiple_count": "Number of Trains for Severe Disruption Alert",
           "night_updates": "Enable Night-Time Updates"
         }
       }
@@ -49,9 +49,9 @@
         "data": {
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
-          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
-          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
-          "disruption_multiple_count": "Number of Trains for Alert",
+          "disruption_single_delay": "Severe Disruption Threshold - Single Train (minutes)",
+          "disruption_multiple_delay": "Severe Disruption Threshold - Multiple Trains (minutes)",
+          "disruption_multiple_count": "Number of Trains for Severe Disruption Alert",
           "night_updates": "Enable Night-Time Updates"
         }
       }

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -23,9 +23,9 @@
           "commute_name": "Commute Name",
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
-          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
-          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
-          "disruption_multiple_count": "Number of Trains for Alert",
+          "disruption_single_delay": "Severe Disruption Threshold - Single Train (minutes)",
+          "disruption_multiple_delay": "Severe Disruption Threshold - Multiple Trains (minutes)",
+          "disruption_multiple_count": "Number of Trains for Severe Disruption Alert",
           "night_updates": "Enable Night-Time Updates"
         }
       }
@@ -49,9 +49,9 @@
         "data": {
           "time_window": "Time Window (minutes)",
           "num_services": "Number of Services to Track",
-          "disruption_single_delay": "Single Train Delay Threshold (minutes)",
-          "disruption_multiple_delay": "Multiple Trains Delay Threshold (minutes)",
-          "disruption_multiple_count": "Number of Trains for Alert",
+          "disruption_single_delay": "Severe Disruption Threshold - Single Train (minutes)",
+          "disruption_multiple_delay": "Severe Disruption Threshold - Multiple Trains (minutes)",
+          "disruption_multiple_count": "Number of Trains for Severe Disruption Alert",
           "night_updates": "Enable Night-Time Updates"
         }
       }


### PR DESCRIPTION
Resolves confusion between "Severe Disruption", "Status", and "Summary" sensors by consolidating logic and creating a clear hierarchy.

Changes:
- Add unified status calculation in coordinator with 5 levels:
  * Normal: All trains on time
  * Minor Delays: Delays 1-9 minutes
  * Major Delays: Delays ≥10 minutes
  * Severe Disruption: Meets user's configurable thresholds
  * Critical: Any cancellations

- Status sensor now shows unified 5-level hierarchy
  * Uses coordinator's overall_status as single source of truth
  * Clear icon progression: train → train-variant → clock-alert → alert-circle → alert-octagon

- Binary sensor renamed from "Severe Disruption" to "Has Disruption"
  * Simplified to ON (any disruption) / OFF (normal)
  * Removed PROBLEM device class that caused confusing "Problem" display
  * Now serves as simple automation trigger

- Summary sensor improved
  * Removed redundant "Severe disruptions" text
  * Focuses on counts: "3 trains on time", "2 delayed, 1 cancelled"
  * Retains detailed attributes for custom cards

- Updated translations to clarify disruption thresholds now control "Severe Disruption" status level

- Version bump to 1.1.0 for this significant architectural change