### PR TITLE
fix: Add translation key to enable Yes/No display for Has Disruption …

### DIFF
--- a/custom_components/my_rail_commute/binary_sensor.py
+++ b/custom_components/my_rail_commute/binary_sensor.py
@@ -109,6 +109,7 @@ class DisruptionSensor(NationalRailCommuteBinarySensor):
 
         self._attr_name = "Has Disruption"
         self._attr_unique_id = f"{entry.entry_id}_disruption"
+        self._attr_translation_key = "disruption"
         # No device_class - removes "Problem" display in UI
         self._attr_icon = "mdi:alert-circle"
 


### PR DESCRIPTION
…sensor

The binary sensor was missing the translation_key attribute needed to link it to the state translations in strings.json. This caused it to display "on"/"off" instead of "Yes"/"No".