### PR TITLE
Handle HTTP 400 errors as invalid CRS station codes

### DIFF
--- a/custom_components/my_rail_commute/api.py
+++ b/custom_components/my_rail_commute/api.py
@@ -118,6 +118,14 @@ class NationalRailAPI:
                             )
                         raise RateLimitError(ERROR_RATE_LIMIT)
 
+                    if response.status == 400:
+                        _LOGGER.error(
+                            "Invalid request (400) for endpoint: %s. "
+                            "This typically indicates an invalid CRS station code",
+                            endpoint,
+                        )
+                        raise InvalidStationError(ERROR_INVALID_STATION)
+
                     if response.status == 404:
                         _LOGGER.error("Station not found (404) for endpoint: %s", endpoint)
                         raise InvalidStationError(ERROR_INVALID_STATION)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,6 +138,17 @@ class TestValidateStation:
             with pytest.raises(InvalidStationError):
                 await api_client.validate_station("XYZ")
 
+    async def test_validate_station_bad_request(self, api_client):
+        """Test station validation with 400 bad request (invalid CRS code)."""
+        with aioresponses() as mock:
+            mock.get(
+                f"{API_BASE_URL}/GetDepartureBoard/PAS?numRows=1",
+                status=400,
+            )
+
+            with pytest.raises(InvalidStationError):
+                await api_client.validate_station("PAS")
+
     async def test_validate_station_uppercase_conversion(self, api_client):
         """Test that station codes are converted to uppercase."""
         with aioresponses() as mock:
@@ -210,6 +221,17 @@ class TestGetDepartureBoard:
 
             with pytest.raises(InvalidStationError):
                 await api_client.get_departure_board("XYZ", "RDG")
+
+    async def test_get_departure_board_bad_request(self, api_client):
+        """Test departure board with 400 bad request (invalid CRS code)."""
+        with aioresponses() as mock:
+            mock.get(
+                f"{API_BASE_URL}/GetDepBoardWithDetails/PAS?filterCrs=RDG&timeWindow=60&numRows=10",
+                status=400,
+            )
+
+            with pytest.raises(InvalidStationError):
+                await api_client.get_departure_board("PAS", "RDG")
 
 
 class TestParseService:


### PR DESCRIPTION
Previously, a 400 response from the Rail API fell through to the generic ClientResponseError handler, producing misleading logs: "Unhandled HTTP error 400: Bad Request" and "Rail API is currently unavailable." Now 400 errors are explicitly caught in _request() and raise InvalidStationError with a clear log message indicating an invalid CRS station code.

https://claude.ai/code/session_014hto8udqc3vzs9hsEbKg6F