### PR TITLE
Fix handling of invalid time formats in _filter_departed_trains

### DIFF
--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -260,7 +260,10 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 continue
 
             # Get departure time (prefer expected, fallback to scheduled)
-            departure_time = service.get("expected_departure") or service.get("scheduled_departure")
+            if "expected_departure" in service:
+                departure_time = service["expected_departure"]
+            else:
+                departure_time = service.get("scheduled_departure")
 
             if not departure_time or not _TIME_FORMAT_RE.match(departure_time):
                 # If we can't parse the time, keep the service


### PR DESCRIPTION
Fixed the issue where empty strings and None values for expected_departure were being converted to scheduled_departure due to the 'or' operator treating them as falsy. Now explicitly checks if 'expected_departure' key exists in the service dict before falling back to scheduled_departure.

This ensures that None and empty string values are treated as invalid time formats and the service is kept (not filtered out), as expected by the tests.

Fixes test_filter_departed_trains_keeps_invalid_time_format for both empty string and None cases.

https://claude.ai/code/session_01AsF4RBSUw95GUP2m8gq3xL