### PR TITLE
Fix session resource leak on integration unload

### DIFF
--- a/custom_components/my_rail_commute/__init__.py
+++ b/custom_components/my_rail_commute/__init__.py
@@ -97,6 +97,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Unload platforms
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        # Clean up API resources before removing coordinator
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        await coordinator.api.close()
+
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/my_rail_commute/api.py
+++ b/custom_components/my_rail_commute/api.py
@@ -589,3 +589,14 @@ class NationalRailAPI:
         except Exception as err:
             _LOGGER.error("API key validation error: %s", err)
             raise AuthenticationError(ERROR_AUTH) from err
+
+    async def close(self) -> None:
+        """Close the API client and clean up resources.
+
+        This should be called when the API client is no longer needed to ensure
+        proper cleanup of the aiohttp ClientSession and prevent resource leaks.
+        """
+        if self._session and not self._session.closed:
+            _LOGGER.debug("Closing aiohttp ClientSession")
+            await self._session.close()
+        self._session = None


### PR DESCRIPTION
- Add close() method to NationalRailAPI to properly close aiohttp ClientSession
- Call api.close() in async_unload_entry before removing coordinator
- Prevents resource leaks and unclosed connections when integration is unloaded

Fixes resource leak where aiohttp ClientSession was never explicitly closed during integration lifecycle.

https://claude.ai/code/session_01Kqpah2f1q8BSNeX4wKce9v