### PR TITLE
Fix platform attribute bugs for better automation support

### DIFF
--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -174,7 +174,7 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
                 "train_number": idx,
                 "scheduled_departure": service.get("scheduled_departure"),
                 "expected_departure": service.get("expected_departure"),
-                "platform": service.get("platform") or "TBA",
+                "platform": service.get("platform"),
                 "operator": service.get("operator"),
                 "service_id": service.get("service_id"),
                 "status": service.get("status"),
@@ -390,7 +390,8 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
             current_service_id = train.get("service_id")
 
             # Handle platform change detection for the same service
-            if current_service_id and current_service_id == self._current_service_id:
+            # Only track platform changes if both current and previous service have valid IDs
+            if current_service_id and self._current_service_id and current_service_id == self._current_service_id:
                 # Same service - check for platform change
                 if self._previous_platform != current_platform:
                     if self._previous_platform is not None:
@@ -511,7 +512,7 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
             "departure_time": departure_time,  # Moved from state to attribute
             ATTR_SCHEDULED_DEPARTURE: train.get("scheduled_departure"),
             ATTR_EXPECTED_DEPARTURE: train.get("expected_departure"),
-            ATTR_PLATFORM: train.get("platform") or "TBA",
+            ATTR_PLATFORM: train.get("platform"),
             "platform_changed": self._platform_changed,
             "previous_platform": self._previous_platform if self._platform_changed else None,
             ATTR_OPERATOR: train.get("operator"),
@@ -604,7 +605,8 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
             current_service_id = train.get("service_id")
 
             # Handle platform change detection for the same service
-            if current_service_id and current_service_id == self._current_service_id:
+            # Only track platform changes if both current and previous service have valid IDs
+            if current_service_id and self._current_service_id and current_service_id == self._current_service_id:
                 # Same service - check for platform change
                 if self._previous_platform != current_platform:
                     if self._previous_platform is not None:
@@ -722,7 +724,7 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
             "departure_time": departure_time,  # Moved from state to attribute
             ATTR_SCHEDULED_DEPARTURE: train.get("scheduled_departure"),
             ATTR_EXPECTED_DEPARTURE: train.get("expected_departure"),
-            ATTR_PLATFORM: train.get("platform") or "TBA",
+            ATTR_PLATFORM: train.get("platform"),
             "platform_changed": self._platform_changed,
             "previous_platform": self._previous_platform if self._platform_changed else None,
             ATTR_OPERATOR: train.get("operator"),


### PR DESCRIPTION
- Change platform attribute to use None instead of "TBA" string for empty values This makes conditional logic in automation templates easier and more reliable
- Add validation for service_id before comparing in platform change detection This prevents false "platform changed" indicators when trains change without valid service IDs

https://claude.ai/code/session_01JW4F67CTCJH6TC2DZZQH1RW8