### PR TITLE
Fix race condition in update interval adjustment

### DIFF
--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for My Rail Commute integration."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from datetime import datetime, timedelta
@@ -68,6 +69,7 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         self.config = config
         self._failed_updates = 0
         self._max_failed_updates = 3
+        self._update_interval_lock = asyncio.Lock()
 
         # Get configuration
         self.origin = config[CONF_ORIGIN]
@@ -168,10 +170,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Starting data update for %s -> %s", self.origin, self.destination)
 
         # Update interval may have changed (e.g., switching between peak/off-peak/night)
-        new_interval = self._get_update_interval()
-        if new_interval != self.update_interval:
-            _LOGGER.debug("Updating interval from %s to %s", self.update_interval, new_interval)
-            self.update_interval = new_interval
+        # Use async lock to prevent race conditions with concurrent updates
+        async with self._update_interval_lock:
+            new_interval = self._get_update_interval()
+            if new_interval != self.update_interval:
+                _LOGGER.debug("Updating interval from %s to %s", self.update_interval, new_interval)
+                self.update_interval = new_interval
 
         try:
             _LOGGER.debug(


### PR DESCRIPTION
Added async lock to protect update interval changes in _async_update_data method, preventing concurrent updates from causing scheduling inconsistencies.

- Added asyncio.Lock instance variable in coordinator initialization
- Wrapped update interval modification in async lock context manager
- Ensures thread-safe access to self.update_interval during concurrent updates

Fixes issue at coordinator.py:144-148 where update interval was changed during _async_update_data without proper synchronization.

https://claude.ai/code/session_01DzybXQKJPYAX3bLbrRjSrF