### PR TITLE
Fix: Add service_id validation to prevent platform tracking issues

### DIFF
--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -389,9 +389,18 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
             current_platform = train.get("platform") or ""
             current_service_id = train.get("service_id")
 
-            # Handle platform change detection for the same service
-            # Only track platform changes if both current and previous service have valid IDs
-            if current_service_id and self._current_service_id and current_service_id == self._current_service_id:
+            # Validate service_id is not empty/None before tracking
+            # Empty or None service_id cannot be reliably used for platform change detection
+            if not current_service_id or (isinstance(current_service_id, str) and not current_service_id.strip()):
+                # Invalid service_id - reset tracking and skip platform change detection
+                _LOGGER.debug(
+                    "Train %d: Invalid service_id (empty/None), skipping platform tracking",
+                    self._train_number,
+                )
+                self._platform_changed = False
+                self._previous_platform = None
+                self._current_service_id = None
+            elif self._current_service_id and current_service_id == self._current_service_id:
                 # Same service - check for platform change
                 if self._previous_platform != current_platform:
                     if self._previous_platform is not None:
@@ -604,9 +613,17 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
             current_platform = train.get("platform") or ""
             current_service_id = train.get("service_id")
 
-            # Handle platform change detection for the same service
-            # Only track platform changes if both current and previous service have valid IDs
-            if current_service_id and self._current_service_id and current_service_id == self._current_service_id:
+            # Validate service_id is not empty/None before tracking
+            # Empty or None service_id cannot be reliably used for platform change detection
+            if not current_service_id or (isinstance(current_service_id, str) and not current_service_id.strip()):
+                # Invalid service_id - reset tracking and skip platform change detection
+                _LOGGER.debug(
+                    "Next train: Invalid service_id (empty/None), skipping platform tracking",
+                )
+                self._platform_changed = False
+                self._previous_platform = None
+                self._current_service_id = None
+            elif self._current_service_id and current_service_id == self._current_service_id:
                 # Same service - check for platform change
                 if self._previous_platform != current_platform:
                     if self._previous_platform is not None:

--- a/tests/test_sensor_platform_changes.py
+++ b/tests/test_sensor_platform_changes.py
@@ -225,7 +225,7 @@ def test_platform_change_from_tba_unit():
 
 
 def test_platform_change_no_service_id():
-    """Unit test for handling missing service_id."""
+    """Unit test for handling missing/invalid service_id."""
     # Create a mock coordinator
     mock_coordinator = MagicMock()
     mock_entry = MagicMock()
@@ -238,7 +238,7 @@ def test_platform_change_no_service_id():
     sensor.hass = MagicMock()
     sensor.async_write_ha_state = MagicMock()
 
-    # Test: Update with missing service_id
+    # Test 1: Update with missing service_id (None)
     mock_coordinator.data = {
         "services": [
             {
@@ -250,8 +250,42 @@ def test_platform_change_no_service_id():
     }
     sensor._handle_coordinator_update()
 
-    # Should still set platform but not track service
-    assert sensor._previous_platform == "3"
+    # Should reset tracking when service_id is None
+    assert sensor._previous_platform is None
+    assert sensor._current_service_id is None
+    assert sensor._platform_changed is False
+
+    # Test 2: Update with empty string service_id
+    mock_coordinator.data = {
+        "services": [
+            {
+                "platform": "4",
+                "service_id": "",
+                "scheduled_departure": "08:40",
+            }
+        ]
+    }
+    sensor._handle_coordinator_update()
+
+    # Should reset tracking when service_id is empty string
+    assert sensor._previous_platform is None
+    assert sensor._current_service_id is None
+    assert sensor._platform_changed is False
+
+    # Test 3: Update with whitespace-only service_id
+    mock_coordinator.data = {
+        "services": [
+            {
+                "platform": "5",
+                "service_id": "   ",
+                "scheduled_departure": "08:45",
+            }
+        ]
+    }
+    sensor._handle_coordinator_update()
+
+    # Should reset tracking when service_id is whitespace-only
+    assert sensor._previous_platform is None
     assert sensor._current_service_id is None
     assert sensor._platform_changed is False
 


### PR DESCRIPTION
- Validate service_id is not None, empty, or whitespace-only before tracking
- Reset platform change tracking when service_id is invalid
- Prevents comparison issues that break platform change detection
- Updated tests to verify handling of invalid service_id values

Fixes sensor.py:383, 597 where empty/None service_id could cause issues

https://claude.ai/code/session_01C7UH4occJRntBWBk2DegQ9