### PR TITLE
Fix silent datetime parsing failure in stale data age calculation

### DIFF
--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -231,12 +231,21 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                                 age.total_seconds() / 3600
                             )
                             raise UpdateFailed(f"Failed to fetch data and cached data too old: {err}") from err
-                except (ValueError, TypeError):
-                    pass
+                    else:
+                        _LOGGER.error(
+                            "Failed to parse last_updated timestamp '%s', cannot verify data age",
+                            self.data.get("last_updated")
+                        )
+                except (ValueError, TypeError) as parse_err:
+                    _LOGGER.error(
+                        "Error parsing last_updated timestamp '%s': %s - cannot verify data age",
+                        self.data.get("last_updated"),
+                        parse_err
+                    )
 
             # Otherwise, return last known data if available and recent
             if self.data:
-                _LOGGER.warning("Using last known data after failed update (data age: recent)")
+                _LOGGER.warning("Using last known data after failed update (data age: unverified)")
                 return self.data
 
             raise UpdateFailed(f"Failed to fetch data: {err}") from err


### PR DESCRIPTION
When dt_util.parse_datetime() fails or returns None while checking cached data age, the exception was caught silently without logging. This could result in returning very old data without warning users.

Changes:
- Add explicit error logging when parse_datetime returns None
- Add error logging when parse_datetime raises ValueError/TypeError
- Update warning message to indicate data age is unverified when parsing fails
- Users now see clear error messages when timestamp parsing fails

Location: coordinator.py:234-248

https://claude.ai/code/session_01AYbLbm7qqYCThNDBUWRghW