### PR TITLE
Make departed train grace period configurable

### DIFF
--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -21,6 +21,7 @@ from .api import (
 )
 from .const import (
     CONF_COMMUTE_NAME,
+    CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
     CONF_DISRUPTION_MULTIPLE_COUNT,
     CONF_DISRUPTION_MULTIPLE_DELAY,
@@ -32,6 +33,7 @@ from .const import (
     CONF_ORIGIN,
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
+    DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
     DEFAULT_MAJOR_DELAY_THRESHOLD,
     DEFAULT_MINOR_DELAY_THRESHOLD,
     DEFAULT_NAME,
@@ -41,9 +43,11 @@ from .const import (
     DEFAULT_TIME_WINDOW,
     DOMAIN,
     MAX_DELAY_THRESHOLD,
+    MAX_GRACE_PERIOD,
     MAX_NUM_SERVICES,
     MAX_TIME_WINDOW,
     MIN_DELAY_THRESHOLD,
+    MIN_GRACE_PERIOD,
     MIN_NUM_SERVICES,
     MIN_TIME_WINDOW,
 )
@@ -308,6 +312,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_SEVERE_DELAY_THRESHOLD: user_input[CONF_SEVERE_DELAY_THRESHOLD],
                     CONF_MAJOR_DELAY_THRESHOLD: user_input[CONF_MAJOR_DELAY_THRESHOLD],
                     CONF_MINOR_DELAY_THRESHOLD: user_input[CONF_MINOR_DELAY_THRESHOLD],
+                    CONF_DEPARTED_TRAIN_GRACE_PERIOD: user_input[CONF_DEPARTED_TRAIN_GRACE_PERIOD],
                 },
             )
 
@@ -383,6 +388,18 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_NIGHT_UPDATES,
                     default=DEFAULT_NIGHT_UPDATES,
                 ): selector.BooleanSelector(),
+                vol.Required(
+                    CONF_DEPARTED_TRAIN_GRACE_PERIOD,
+                    default=DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=MIN_GRACE_PERIOD,
+                        max=MAX_GRACE_PERIOD,
+                        step=1,
+                        unit_of_measurement="minutes",
+                        mode=selector.NumberSelectorMode.SLIDER,
+                    ),
+                ),
             }
         )
 
@@ -539,6 +556,21 @@ class NationalRailCommuteOptionsFlow(config_entries.OptionsFlow):
                         current_data.get(CONF_NIGHT_UPDATES, DEFAULT_NIGHT_UPDATES),
                     ),
                 ): selector.BooleanSelector(),
+                vol.Required(
+                    CONF_DEPARTED_TRAIN_GRACE_PERIOD,
+                    default=options.get(
+                        CONF_DEPARTED_TRAIN_GRACE_PERIOD,
+                        current_data.get(CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD),
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=MIN_GRACE_PERIOD,
+                        max=MAX_GRACE_PERIOD,
+                        step=1,
+                        unit_of_measurement="minutes",
+                        mode=selector.NumberSelectorMode.SLIDER,
+                    ),
+                ),
             }
         )
 

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -15,6 +15,7 @@ CONF_NIGHT_UPDATES: Final = "night_updates"
 CONF_SEVERE_DELAY_THRESHOLD: Final = "severe_delay_threshold"
 CONF_MAJOR_DELAY_THRESHOLD: Final = "major_delay_threshold"
 CONF_MINOR_DELAY_THRESHOLD: Final = "minor_delay_threshold"
+CONF_DEPARTED_TRAIN_GRACE_PERIOD: Final = "departed_train_grace_period"
 
 # Legacy config keys (for migration)
 CONF_DISRUPTION_SINGLE_DELAY: Final = "disruption_single_delay"
@@ -30,12 +31,15 @@ DEFAULT_TIME_WINDOW: Final = 60
 DEFAULT_NUM_SERVICES: Final = 3
 DEFAULT_NIGHT_UPDATES: Final = False
 DEFAULT_NAME: Final = "My Rail Commute"
+DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD: Final = 5  # minutes
 
 # Limits
 MIN_TIME_WINDOW: Final = 15
 MAX_TIME_WINDOW: Final = 120
 MIN_NUM_SERVICES: Final = 1
 MAX_NUM_SERVICES: Final = 10
+MIN_GRACE_PERIOD: Final = 0  # minutes
+MAX_GRACE_PERIOD: Final = 15  # minutes
 
 # Update intervals (in minutes)
 UPDATE_INTERVAL_PEAK: Final = timedelta(minutes=2)

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.util import dt as dt_util
 
 from .api import NationalRailAPI, NationalRailAPIError
 from .const import (
+    CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
     CONF_DISRUPTION_MULTIPLE_COUNT,
     CONF_DISRUPTION_MULTIPLE_DELAY,
@@ -24,6 +25,7 @@ from .const import (
     CONF_ORIGIN,
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
+    DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
     DEFAULT_MAJOR_DELAY_THRESHOLD,
     DEFAULT_MINOR_DELAY_THRESHOLD,
     DEFAULT_SEVERE_DELAY_THRESHOLD,
@@ -77,6 +79,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         self.time_window = int(config[CONF_TIME_WINDOW])
         self.num_services = int(config[CONF_NUM_SERVICES])
         self.night_updates_enabled = config.get(CONF_NIGHT_UPDATES, False)
+        self.departed_train_grace_period = int(
+            config.get(CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD)
+        )
 
         # Delay thresholds (user-configurable)
         # Support migration from old config format
@@ -303,8 +308,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                     time_diff_seconds = (departure_dt - current_dt).total_seconds()
 
                 # Keep the train if it hasn't departed yet
-                # Add a 2-minute grace period to account for update delays
-                if time_diff_seconds >= -120:  # -2 minutes
+                # Add a grace period to account for update delays and slight delays
+                grace_period_seconds = self.departed_train_grace_period * 60
+                if time_diff_seconds >= -grace_period_seconds:
                     filtered_services.append(service)
                 else:
                     _LOGGER.debug(


### PR DESCRIPTION
The previous 2-minute grace period was too aggressive and could filter out trains that are only slightly delayed, causing valid trains to disappear from the list.

Changes:
- Add CONF_DEPARTED_TRAIN_GRACE_PERIOD configuration option
- Set default grace period to 5 minutes (increased from 2 minutes)
- Allow users to configure the grace period between 0-15 minutes
- Update coordinator to use the configurable value instead of hard-coded -120 seconds
- Add grace period setting to both initial setup flow and options flow

Fixes coordinator.py:259 where the grace period was previously hard-coded

https://claude.ai/code/session_01BSAiC9FxqJ9AcAEghBxTq4