### PR TITLE
Fix journey time using terminus instead of configured destination

### DIFF
--- a/custom_components/my_rail_commute/api.py
+++ b/custom_components/my_rail_commute/api.py
@@ -378,14 +378,14 @@ class NationalRailAPI:
 
         try:
             data = await self._request(endpoint, params)
-            return self._parse_departure_board(data)
+            return self._parse_departure_board(data, destination_crs)
         except InvalidStationError:
             raise
         except NationalRailAPIError as err:
             _LOGGER.error("Failed to get departure board: %s", err)
             raise
 
-    def _parse_departure_board(self, data: dict[str, Any]) -> dict[str, Any]:
+    def _parse_departure_board(self, data: dict[str, Any], destination_crs: str | None = None) -> dict[str, Any]:
         """Parse departure board response.
 
         Args:
@@ -409,7 +409,7 @@ class NationalRailAPI:
 
         parsed_services = []
         for service in services_list:
-            parsed_service = self._parse_service(service)
+            parsed_service = self._parse_service(service, destination_crs)
             if parsed_service:
                 parsed_services.append(parsed_service)
 
@@ -421,7 +421,7 @@ class NationalRailAPI:
             "nrcc_messages": board.get("nrccMessages", []),
         }
 
-    def _parse_service(self, service: dict[str, Any]) -> dict[str, Any] | None:
+    def _parse_service(self, service: dict[str, Any], destination_crs: str | None = None) -> dict[str, Any] | None:
         """Parse a single train service.
 
         Args:
@@ -493,15 +493,22 @@ class NationalRailAPI:
                     cp.get("locationName", "") for cp in calling_point_list if cp
                 ]
 
-            # Arrival time (use last calling point or estimate)
+            # Arrival time: use configured destination stop, fall back to last calling point
             scheduled_arrival = None
             estimated_arrival = None
             if calling_points and isinstance(subsequent_points, list) and subsequent_points:
                 calling_point_list = subsequent_points[0].get("callingPoint", [])
                 if isinstance(calling_point_list, list) and calling_point_list:
-                    last_point = calling_point_list[-1]
-                    scheduled_arrival = last_point.get("st")
-                    estimated_arrival = last_point.get("et")
+                    dest_point = None
+                    if destination_crs:
+                        for cp in calling_point_list:
+                            if cp.get("crs", "").upper() == destination_crs.upper():
+                                dest_point = cp
+                                break
+                    if dest_point is None:
+                        dest_point = calling_point_list[-1]
+                    scheduled_arrival = dest_point.get("st")
+                    estimated_arrival = dest_point.get("et")
 
             return {
                 "scheduled_departure": std,

--- a/tests/fixtures/departure_board_through_service.json
+++ b/tests/fixtures/departure_board_through_service.json
@@ -1,0 +1,44 @@
+{
+  "GetStationBoardResult": {
+    "generatedAt": "2024-01-15T08:30:00",
+    "locationName": "East Croydon",
+    "crs": "ECR",
+    "filterLocationName": "London Bridge",
+    "filtercrs": "LBG",
+    "trainServices": {
+      "service": [
+        {
+          "std": "08:32",
+          "etd": "On time",
+          "platform": "3",
+          "operator": "Thameslink",
+          "serviceID": "service_ecr_lbg",
+          "destination": [
+            {
+              "locationName": "Cannon Street",
+              "crs": "CST"
+            }
+          ],
+          "subsequentCallingPoints": [
+            {
+              "callingPoint": [
+                {
+                  "locationName": "London Bridge",
+                  "crs": "LBG",
+                  "st": "08:45",
+                  "et": "On time"
+                },
+                {
+                  "locationName": "Cannon Street",
+                  "crs": "CST",
+                  "st": "08:52",
+                  "et": "On time"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -344,6 +344,53 @@ class TestParseService:
         assert result["status"] == STATUS_DELAYED
         assert result["delay_minutes"] == 15  # Crosses midnight
 
+    async def test_parse_service_uses_destination_not_terminus(self, api_client):
+        """Test that scheduled_arrival uses the configured destination, not the terminus."""
+        service_data = {
+            "std": "08:32",
+            "etd": "On time",
+            "platform": "3",
+            "operator": "Thameslink",
+            "serviceID": "service_ecr_lbg",
+            "destination": [{"locationName": "Cannon Street", "crs": "CST"}],
+            "subsequentCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "London Bridge", "crs": "LBG", "st": "08:45", "et": "On time"},
+                        {"locationName": "Cannon Street", "crs": "CST", "st": "08:52", "et": "On time"},
+                    ]
+                }
+            ],
+        }
+
+        result = api_client._parse_service(service_data, destination_crs="LBG")
+
+        assert result["scheduled_arrival"] == "08:45"
+        assert result["estimated_arrival"] == "On time"
+
+    async def test_parse_service_falls_back_to_last_point_when_no_destination_crs(self, api_client):
+        """Test that scheduled_arrival falls back to the last calling point when no destination_crs given."""
+        service_data = {
+            "std": "08:32",
+            "etd": "On time",
+            "platform": "3",
+            "operator": "Thameslink",
+            "serviceID": "service_ecr_cst",
+            "destination": [{"locationName": "Cannon Street", "crs": "CST"}],
+            "subsequentCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "London Bridge", "crs": "LBG", "st": "08:45", "et": "On time"},
+                        {"locationName": "Cannon Street", "crs": "CST", "st": "08:52", "et": "On time"},
+                    ]
+                }
+            ],
+        }
+
+        result = api_client._parse_service(service_data)
+
+        assert result["scheduled_arrival"] == "08:52"
+
     @pytest.mark.parametrize(
         ("std", "etd"),
         [


### PR DESCRIPTION
When a train service continues beyond the configured destination,
scheduled_arrival was set to the final terminus arrival time rather than
the arrival time at the configured destination station.

Thread destination_crs through _parse_departure_board and _parse_service,
then search calling points by CRS code to find the correct stop. Falls
back to the last calling point when no CRS match is found.

https://claude.ai/code/session_017Ct5NipVsUisAMyAAyPGXh