### PR TITLE
Add release workflow to build and attach integration zip

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+
+      - name: Run pytest
+        run: |
+          pytest --cov --cov-report=xml --cov-report=term
+
+  release:
+    name: Build and attach release zip
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify manifest version matches tag
+        run: |
+          MANIFEST_VERSION=$(python -c "import json; print(json.load(open('custom_components/my_rail_commute/manifest.json'))['version'])")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: manifest=$MANIFEST_VERSION tag=$TAG_VERSION"
+            exit 1
+          fi
+
+      - name: Create release zip
+        run: |
+          zip -r my-rail-commute.zip custom_components/my_rail_commute/
+
+      - name: Upload zip to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: my-rail-commute.zip


### PR DESCRIPTION
Adds .github/workflows/release.yaml which triggers on GitHub release
publish (or tag push), runs the test suite as a quality gate, then
zips custom_components/my_rail_commute/ and attaches my-rail-commute.zip
to the release for HACS and manual installation.

https://claude.ai/code/session_015DaTEQa1uuEkbp7iEXTi71