### PR TITLE
Filter calling points to configured destination

### DIFF
--- a/custom_components/my_rail_commute/api.py
+++ b/custom_components/my_rail_commute/api.py
@@ -482,31 +482,32 @@ class NationalRailAPI:
             elif isinstance(destination, dict):
                 destination = destination.get("locationName", "")
 
-            # Subsequent calling points
+            # Subsequent calling points and arrival time
             calling_points = []
+            scheduled_arrival = None
+            estimated_arrival = None
             subsequent_points = service.get("subsequentCallingPoints", [])
             if isinstance(subsequent_points, list) and subsequent_points:
                 calling_point_list = subsequent_points[0].get("callingPoint", [])
                 if not isinstance(calling_point_list, list):
                     calling_point_list = [calling_point_list]
-                calling_points = [
-                    cp.get("locationName", "") for cp in calling_point_list if cp
-                ]
 
-            # Arrival time: use configured destination stop, fall back to last calling point
-            scheduled_arrival = None
-            estimated_arrival = None
-            if calling_points and isinstance(subsequent_points, list) and subsequent_points:
-                calling_point_list = subsequent_points[0].get("callingPoint", [])
-                if isinstance(calling_point_list, list) and calling_point_list:
-                    dest_point = None
-                    if destination_crs:
-                        for cp in calling_point_list:
-                            if cp.get("crs", "").upper() == destination_crs.upper():
-                                dest_point = cp
-                                break
-                    if dest_point is None:
-                        dest_point = calling_point_list[-1]
+                # Build calling points list, truncating at destination if configured
+                dest_point = None
+                filtered = []
+                for cp in calling_point_list:
+                    if not cp:
+                        continue
+                    filtered.append(cp)
+                    if destination_crs and cp.get("crs", "").upper() == destination_crs.upper():
+                        dest_point = cp
+                        break  # Stop collecting stops after the destination
+
+                if dest_point is None and filtered:
+                    dest_point = filtered[-1]
+
+                calling_points = [cp.get("locationName", "") for cp in filtered]
+                if dest_point:
                     scheduled_arrival = dest_point.get("st")
                     estimated_arrival = dest_point.get("et")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -391,6 +391,78 @@ class TestParseService:
 
         assert result["scheduled_arrival"] == "08:52"
 
+    async def test_parse_service_calling_points_filtered_to_destination(self, api_client):
+        """Test that calling_points only includes stops up to and including the destination."""
+        service_data = {
+            "std": "08:32",
+            "etd": "On time",
+            "platform": "3",
+            "operator": "Thameslink",
+            "serviceID": "service_ecr_lbg",
+            "destination": [{"locationName": "Cannon Street", "crs": "CST"}],
+            "subsequentCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "London Bridge", "crs": "LBG", "st": "08:45", "et": "On time"},
+                        {"locationName": "Cannon Street", "crs": "CST", "st": "08:52", "et": "On time"},
+                    ]
+                }
+            ],
+        }
+
+        result = api_client._parse_service(service_data, destination_crs="LBG")
+
+        assert result["calling_points"] == ["London Bridge"]
+        assert "Cannon Street" not in result["calling_points"]
+        assert result["scheduled_arrival"] == "08:45"
+
+    async def test_parse_service_calling_points_unfiltered_without_destination(self, api_client):
+        """Test that calling_points shows all stops when no destination_crs given."""
+        service_data = {
+            "std": "08:32",
+            "etd": "On time",
+            "platform": "3",
+            "operator": "Thameslink",
+            "serviceID": "service_ecr_cst",
+            "destination": [{"locationName": "Cannon Street", "crs": "CST"}],
+            "subsequentCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "London Bridge", "crs": "LBG", "st": "08:45", "et": "On time"},
+                        {"locationName": "Cannon Street", "crs": "CST", "st": "08:52", "et": "On time"},
+                    ]
+                }
+            ],
+        }
+
+        result = api_client._parse_service(service_data)
+
+        assert result["calling_points"] == ["London Bridge", "Cannon Street"]
+
+    async def test_parse_service_calling_points_unfiltered_when_destination_not_found(self, api_client):
+        """Test that all calling_points are kept when destination_crs is not matched."""
+        service_data = {
+            "std": "08:32",
+            "etd": "On time",
+            "platform": "3",
+            "operator": "Thameslink",
+            "serviceID": "service_ecr_xyz",
+            "destination": [{"locationName": "Cannon Street", "crs": "CST"}],
+            "subsequentCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "London Bridge", "crs": "LBG", "st": "08:45", "et": "On time"},
+                        {"locationName": "Cannon Street", "crs": "CST", "st": "08:52", "et": "On time"},
+                    ]
+                }
+            ],
+        }
+
+        result = api_client._parse_service(service_data, destination_crs="XYZ")
+
+        assert result["calling_points"] == ["London Bridge", "Cannon Street"]
+        assert result["scheduled_arrival"] == "08:52"
+
     @pytest.mark.parametrize(
         ("std", "etd"),
         [


### PR DESCRIPTION
Mirrors the journey time fix (5ada40b): just as scheduled_arrival now
uses the configured destination rather than the terminus, calling_points
is now truncated at the destination so both attributes reflect the same
scope of the journey.

Unified the two separate calling-points / arrival-time blocks into a
single loop that breaks early on a CRS match, removing the duplicate
read of calling_point_list. Falls back to all stops when no destination
is configured, preserving existing behaviour.

https://claude.ai/code/session_01Hqj9ffryyyBxaDF9RgSd85