### PR TITLE
Filter release workflow to skip pre-releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [released]
   push:
     tags:
       - "v*.*.*"
@@ -14,6 +14,7 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -37,6 +38,7 @@ jobs:
     name: Build and attach release zip
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ !contains(github.ref_name, '-') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Change release trigger from `published` to `released` so the workflow
  only fires for full releases, not pre-releases
- Add `if: !contains(github.ref_name, '-')` guard to both jobs so that
  tag-push triggers from pre-release tags (e.g. v1.0.0-alpha.1) are
  also skipped

https://claude.ai/code/session_01LtVLMJ6ygxan9CspixYEV5