### PR TITLE
Fix version check to handle uppercase V tag prefix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Verify manifest version matches tag
         run: |
           MANIFEST_VERSION=$(python -c "import json; print(json.load(open('custom_components/my_rail_commute/manifest.json'))['version'])")
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${GITHUB_REF_NAME#[vV]}"
           if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: manifest=$MANIFEST_VERSION tag=$TAG_VERSION"
             exit 1


### PR DESCRIPTION
The bash parameter expansion `${GITHUB_REF_NAME#v}` only strips a
lowercase 'v', causing the version check to fail when tags use an
uppercase 'V' prefix (e.g. V1.1.4). Change to `${GITHUB_REF_NAME#[vV]}`
to handle both cases.

https://claude.ai/code/session_01PpivPcmXPDKyzwKgrJf5bc