### PR TITLE
Add historical performance tracking with persistent daily stats

### DIFF
--- a/custom_components/my_rail_commute/__init__.py
+++ b/custom_components/my_rail_commute/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import NationalRailDataUpdateCoordinator
+from .statistics import CommuteStatisticsStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +60,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             api,
             config,
         )
+
+        # Set up historical statistics store
+        stats_store = CommuteStatisticsStore(hass, entry.entry_id)
+        await stats_store.async_load()
+        coordinator.stats_store = stats_store
 
         # Fetch initial data
         _LOGGER.debug("Fetching initial data for %s -> %s", config[CONF_ORIGIN], config[CONF_DESTINATION])

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -130,3 +130,20 @@ ERROR_NETWORK: Final = "Network error occurred while contacting Rail API."
 
 # User Agent
 USER_AGENT: Final = f"{DOMAIN}/1.0.0"
+
+# Historical statistics storage
+STORAGE_VERSION: Final = 1
+STATS_RETENTION_DAYS: Final = 90
+
+# Attribute names for historical sensors
+ATTR_ON_TIME_PCT_TODAY: Final = "on_time_pct_today"
+ATTR_ON_TIME_PCT_7D: Final = "on_time_pct_7day"
+ATTR_ON_TIME_PCT_30D: Final = "on_time_pct_30day"
+ATTR_AVG_DELAY_TODAY: Final = "avg_delay_today"
+ATTR_AVG_DELAY_7D: Final = "avg_delay_7day"
+ATTR_WORST_DAY: Final = "worst_day"
+ATTR_BEST_DAY: Final = "best_day"
+ATTR_TOTAL_OBSERVATIONS_TODAY: Final = "total_observations_today"
+ATTR_ON_TIME_COUNT_TODAY: Final = "on_time_count_today"
+ATTR_DELAYED_COUNT_TODAY: Final = "delayed_count_today"
+ATTR_CANCELLED_COUNT_TODAY: Final = "cancelled_count_today"

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -126,6 +126,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         self.origin_name: str | None = None
         self.destination_name: str | None = None
 
+        # Historical stats recorder — attached externally by async_setup_entry
+        self.stats_store: Any | None = None
+
         # Initialize with off-peak interval
         update_interval = self._get_update_interval()
 
@@ -203,6 +206,10 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Parse and enrich data
             parsed_data = self._parse_data(data)
+
+            # Record observation in historical stats store
+            if self.stats_store is not None:
+                await self.stats_store.async_record_observation(parsed_data)
 
             # Reset failed update counter on success
             self._failed_updates = 0

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -13,18 +13,27 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from .const import (
+    ATTR_AVG_DELAY_7D,
+    ATTR_AVG_DELAY_TODAY,
+    ATTR_BEST_DAY,
     ATTR_CALLING_POINTS,
     ATTR_CANCELLATION_REASON,
     ATTR_CANCELLED_COUNT,
+    ATTR_CANCELLED_COUNT_TODAY,
     ATTR_DELAY_MINUTES,
     ATTR_DELAY_REASON,
     ATTR_DELAYED_COUNT,
+    ATTR_DELAYED_COUNT_TODAY,
     ATTR_DESTINATION,
     ATTR_DESTINATION_NAME,
     ATTR_ESTIMATED_ARRIVAL,
     ATTR_EXPECTED_DEPARTURE,
     ATTR_IS_CANCELLED,
     ATTR_ON_TIME_COUNT,
+    ATTR_ON_TIME_COUNT_TODAY,
+    ATTR_ON_TIME_PCT_30D,
+    ATTR_ON_TIME_PCT_7D,
+    ATTR_ON_TIME_PCT_TODAY,
     ATTR_OPERATOR,
     ATTR_ORIGIN,
     ATTR_ORIGIN_NAME,
@@ -35,7 +44,9 @@ from .const import (
     ATTR_SERVICES_TRACKED,
     ATTR_STATUS,
     ATTR_TIME_WINDOW,
+    ATTR_TOTAL_OBSERVATIONS_TODAY,
     ATTR_TOTAL_SERVICES,
+    ATTR_WORST_DAY,
     CONF_COMMUTE_NAME,
     CONF_NUM_SERVICES,
     DOMAIN,
@@ -78,6 +89,10 @@ async def async_setup_entry(
     # Create individual train sensors dynamically based on configuration
     for train_number in range(1, num_trains + 1):
         entities.append(TrainSensor(coordinator, entry, train_number))
+
+    # Historical performance sensors
+    entities.append(HistoricalReliabilitySensor(coordinator, entry))
+    entities.append(HistoricalDelaysSensor(coordinator, entry))
 
     _LOGGER.debug(
         "Setting up %d sensor entities for %s -> %s",
@@ -792,3 +807,87 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
             return "Expected"
 
         return "On Time"
+
+
+class HistoricalReliabilitySensor(NationalRailCommuteEntity, SensorEntity):
+    """Sensor exposing on-time percentage over rolling windows."""
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = "Historical Reliability"
+        self._attr_unique_id = f"{entry.entry_id}_historical_reliability"
+        self._attr_icon = "mdi:chart-line"
+        self._attr_native_unit_of_measurement = "%"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> float | None:
+        if self.coordinator.stats_store is None:
+            return None
+        return self.coordinator.stats_store.get_rolling_stats(7)["on_time_pct"]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        store = self.coordinator.stats_store
+        if store is None:
+            return {}
+
+        today = store.get_today_stats()
+        rolling_7 = store.get_rolling_stats(7)
+        rolling_30 = store.get_rolling_stats(30)
+
+        return {
+            ATTR_ON_TIME_PCT_TODAY: today.get("on_time_pct"),
+            ATTR_ON_TIME_PCT_7D: rolling_7["on_time_pct"],
+            ATTR_ON_TIME_PCT_30D: rolling_30["on_time_pct"],
+            ATTR_ON_TIME_COUNT_TODAY: today.get("on_time_count", 0),
+            ATTR_DELAYED_COUNT_TODAY: today.get("delayed_count", 0),
+            ATTR_CANCELLED_COUNT_TODAY: today.get("cancelled_count", 0),
+            ATTR_TOTAL_OBSERVATIONS_TODAY: today.get("total_observations", 0),
+            "days_with_data_7day": rolling_7["days_with_data"],
+            "days_with_data_30day": rolling_30["days_with_data"],
+        }
+
+
+class HistoricalDelaysSensor(NationalRailCommuteEntity, SensorEntity):
+    """Sensor exposing average delay statistics over rolling windows."""
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = "Historical Delays"
+        self._attr_unique_id = f"{entry.entry_id}_historical_delays"
+        self._attr_icon = "mdi:clock-alert-outline"
+        self._attr_native_unit_of_measurement = "min"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> float | None:
+        if self.coordinator.stats_store is None:
+            return None
+        return self.coordinator.stats_store.get_rolling_stats(7)["avg_delay_minutes"]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        store = self.coordinator.stats_store
+        if store is None:
+            return {}
+
+        today = store.get_today_stats()
+        rolling_7 = store.get_rolling_stats(7)
+        best_worst = store.get_best_and_worst_days(30)
+
+        return {
+            ATTR_AVG_DELAY_TODAY: today.get("avg_delay_minutes"),
+            ATTR_AVG_DELAY_7D: rolling_7["avg_delay_minutes"],
+            ATTR_WORST_DAY: best_worst["worst_day"],
+            ATTR_BEST_DAY: best_worst["best_day"],
+            "days_with_data_7day": rolling_7["days_with_data"],
+        }

--- a/custom_components/my_rail_commute/statistics.py
+++ b/custom_components/my_rail_commute/statistics.py
@@ -1,0 +1,138 @@
+"""Persistent daily statistics storage for My Rail Commute integration."""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN, STATS_RETENTION_DAYS, STORAGE_VERSION, STATUS_DELAYED
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CommuteStatisticsStore:
+    """Manages persistent daily commute statistics using HA's Store."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        self._store = Store(hass, STORAGE_VERSION, f"{DOMAIN}_{entry_id}_stats")
+        self._data: dict[str, Any] = {}
+
+    async def async_load(self) -> None:
+        """Load persisted data from storage."""
+        raw = await self._store.async_load()
+        if raw is None:
+            self._data = {}
+        else:
+            self._data = raw.get("days", {})
+        self._prune_old_entries()
+        _LOGGER.debug("Loaded %d days of historical stats", len(self._data))
+
+    async def async_record_observation(self, parsed_data: dict[str, Any]) -> None:
+        """Accumulate today's observation from a coordinator update and persist."""
+        if parsed_data.get("services_tracked", 0) == 0:
+            _LOGGER.debug("Skipping stats recording: no services tracked in this update")
+            return
+
+        today_key = dt_util.now().date().isoformat()
+        day = self._data.get(today_key, {
+            "on_time_count": 0,
+            "delayed_count": 0,
+            "cancelled_count": 0,
+            "total_observations": 0,
+            "total_delay_minutes": 0,
+        })
+
+        on_time = parsed_data.get("on_time_count", 0)
+        delayed = parsed_data.get("delayed_count", 0)
+        cancelled = parsed_data.get("cancelled_count", 0)
+        obs = on_time + delayed + cancelled
+
+        total_delay = sum(
+            s.get("delay_minutes", 0)
+            for s in parsed_data.get("services", [])
+            if s.get("status") == STATUS_DELAYED and not s.get("is_cancelled", False)
+        )
+
+        day["on_time_count"] += on_time
+        day["delayed_count"] += delayed
+        day["cancelled_count"] += cancelled
+        day["total_observations"] += obs
+        day["total_delay_minutes"] += total_delay
+
+        total_obs = day["total_observations"]
+        day["on_time_pct"] = round(day["on_time_count"] / total_obs * 100, 2) if total_obs > 0 else 0.0
+        day["avg_delay_minutes"] = (
+            round(day["total_delay_minutes"] / day["delayed_count"], 2)
+            if day["delayed_count"] > 0
+            else 0.0
+        )
+
+        self._data[today_key] = day
+        self._prune_old_entries()
+        await self._store.async_save({"version": STORAGE_VERSION, "days": self._data})
+        _LOGGER.debug(
+            "Recorded stats for %s: on_time=%d delayed=%d cancelled=%d",
+            today_key, on_time, delayed, cancelled,
+        )
+
+    def get_today_stats(self) -> dict[str, Any]:
+        """Return today's accumulated stats, or an empty dict if no data yet."""
+        return self._data.get(dt_util.now().date().isoformat(), {})
+
+    def get_rolling_stats(self, days: int) -> dict[str, Any]:
+        """Return aggregated stats across the last `days` calendar days (today included)."""
+        today = dt_util.now().date()
+        window = [(today - timedelta(days=i)).isoformat() for i in range(days)]
+        days_with_data = [d for d in window if d in self._data]
+
+        if not days_with_data:
+            return {"on_time_pct": None, "avg_delay_minutes": None, "days_with_data": 0}
+
+        total_on_time = sum(self._data[d]["on_time_count"] for d in days_with_data)
+        total_obs = sum(self._data[d]["total_observations"] for d in days_with_data)
+        total_delayed = sum(self._data[d]["delayed_count"] for d in days_with_data)
+        total_delay_min = sum(self._data[d]["total_delay_minutes"] for d in days_with_data)
+
+        return {
+            "on_time_pct": round(total_on_time / total_obs * 100, 1) if total_obs > 0 else None,
+            "avg_delay_minutes": round(total_delay_min / total_delayed, 1) if total_delayed > 0 else None,
+            "days_with_data": len(days_with_data),
+        }
+
+    def get_best_and_worst_days(self, days: int = 30) -> dict[str, Any]:
+        """Return worst/best day (by on-time %) across the last `days` calendar days."""
+        today = dt_util.now().date()
+        window = [(today - timedelta(days=i)).isoformat() for i in range(days)]
+        candidates = {d: self._data[d] for d in window if d in self._data and self._data[d].get("total_observations", 0) > 0}
+
+        if not candidates:
+            return {"worst_day": None, "best_day": None}
+
+        worst = min(candidates, key=lambda d: candidates[d].get("on_time_pct", 100))
+        best = max(candidates, key=lambda d: candidates[d].get("on_time_pct", 0))
+
+        return {
+            "worst_day": {
+                "date": worst,
+                "on_time_pct": candidates[worst].get("on_time_pct"),
+                "avg_delay_minutes": candidates[worst].get("avg_delay_minutes"),
+            },
+            "best_day": {
+                "date": best,
+                "on_time_pct": candidates[best].get("on_time_pct"),
+                "avg_delay_minutes": candidates[best].get("avg_delay_minutes"),
+            },
+        }
+
+    def _prune_old_entries(self) -> None:
+        """Remove entries older than STATS_RETENTION_DAYS."""
+        cutoff = (dt_util.now().date() - timedelta(days=STATS_RETENTION_DAYS)).isoformat()
+        stale = [key for key in self._data if key < cutoff]
+        for key in stale:
+            del self._data[key]
+        if stale:
+            _LOGGER.debug("Pruned %d stale stats entries (older than %s)", len(stale), cutoff)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -71,7 +71,7 @@ async def test_record_new_day():
 
     today = date.today().isoformat()
     with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
-        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        mock_dt.now.return_value.date.return_value = date.fromisoformat(today)
         await store.async_record_observation(_parsed_data(on_time=2, delayed=1, cancelled=0))
 
     assert today in store._data
@@ -91,7 +91,7 @@ async def test_record_same_day_accumulates():
     today = "2026-05-17"
 
     with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
-        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        mock_dt.now.return_value.date.return_value = date.fromisoformat(today)
         await store.async_record_observation(_parsed_data(on_time=2, delayed=1, cancelled=0))
         await store.async_record_observation(_parsed_data(on_time=1, delayed=0, cancelled=1))
 
@@ -110,7 +110,7 @@ async def test_record_zero_services_skipped():
     today = "2026-05-17"
 
     with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
-        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        mock_dt.now.return_value.date.return_value = date.fromisoformat(today)
         await store.async_record_observation({"services_tracked": 0, "on_time_count": 0,
                                                "delayed_count": 0, "cancelled_count": 0,
                                                "services": []})
@@ -246,7 +246,7 @@ async def test_on_time_pct_computed_correctly():
     today = "2026-05-17"
 
     with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
-        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        mock_dt.now.return_value.date.return_value = date.fromisoformat(today)
         await store.async_record_observation(_parsed_data(on_time=3, delayed=1, cancelled=0))
 
     day = store._data[today]

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,254 @@
+"""Tests for the CommuteStatisticsStore."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.my_rail_commute.statistics import CommuteStatisticsStore
+
+
+def _make_store(load_return=None):
+    """Return a CommuteStatisticsStore with a mocked HA Store."""
+    hass = MagicMock()
+    with patch(
+        "custom_components.my_rail_commute.statistics.Store"
+    ) as MockStore:
+        instance = MockStore.return_value
+        instance.async_load = AsyncMock(return_value=load_return)
+        instance.async_save = AsyncMock(return_value=None)
+        store = CommuteStatisticsStore(hass, "test_entry_id")
+        store._store = instance
+    return store
+
+
+def _parsed_data(on_time=2, delayed=1, cancelled=0, services=None):
+    """Build a minimal parsed_data dict as the coordinator produces."""
+    if services is None:
+        services = []
+        for _ in range(on_time):
+            services.append({"status": "on_time", "delay_minutes": 0, "is_cancelled": False})
+        for dm in range(delayed):
+            services.append({"status": "delayed", "delay_minutes": 5 * (dm + 1), "is_cancelled": False})
+        for _ in range(cancelled):
+            services.append({"status": "cancelled", "delay_minutes": 0, "is_cancelled": True})
+    return {
+        "on_time_count": on_time,
+        "delayed_count": delayed,
+        "cancelled_count": cancelled,
+        "services_tracked": on_time + delayed + cancelled,
+        "services": services,
+    }
+
+
+@pytest.mark.asyncio
+async def test_load_no_data():
+    """async_load with no persisted data initialises empty dict."""
+    store = _make_store(load_return=None)
+    await store.async_load()
+    assert store._data == {}
+
+
+@pytest.mark.asyncio
+async def test_load_existing_data():
+    """async_load restores previously persisted data."""
+    existing = {"days": {"2026-05-17": {"on_time_count": 5, "delayed_count": 1,
+                                         "cancelled_count": 0, "total_observations": 6,
+                                         "total_delay_minutes": 10,
+                                         "on_time_pct": 83.33, "avg_delay_minutes": 10.0}}}
+    store = _make_store(load_return=existing)
+    await store.async_load()
+    assert "2026-05-17" in store._data
+    assert store._data["2026-05-17"]["on_time_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_record_new_day():
+    """First observation of the day creates a new entry and persists."""
+    store = _make_store()
+    await store.async_load()
+
+    today = date.today().isoformat()
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        await store.async_record_observation(_parsed_data(on_time=2, delayed=1, cancelled=0))
+
+    assert today in store._data
+    day = store._data[today]
+    assert day["on_time_count"] == 2
+    assert day["delayed_count"] == 1
+    assert day["cancelled_count"] == 0
+    assert day["total_observations"] == 3
+    store._store.async_save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_record_same_day_accumulates():
+    """Multiple observations on the same day accumulate counts."""
+    store = _make_store()
+    await store.async_load()
+    today = "2026-05-17"
+
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        await store.async_record_observation(_parsed_data(on_time=2, delayed=1, cancelled=0))
+        await store.async_record_observation(_parsed_data(on_time=1, delayed=0, cancelled=1))
+
+    day = store._data[today]
+    assert day["on_time_count"] == 3
+    assert day["delayed_count"] == 1
+    assert day["cancelled_count"] == 1
+    assert day["total_observations"] == 6
+
+
+@pytest.mark.asyncio
+async def test_record_zero_services_skipped():
+    """Observations with zero services_tracked are silently skipped."""
+    store = _make_store()
+    await store.async_load()
+    today = "2026-05-17"
+
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        await store.async_record_observation({"services_tracked": 0, "on_time_count": 0,
+                                               "delayed_count": 0, "cancelled_count": 0,
+                                               "services": []})
+
+    assert today not in store._data
+    store._store.async_save.assert_not_called()
+
+
+def test_prune_removes_old_entries():
+    """_prune_old_entries removes dates older than STATS_RETENTION_DAYS."""
+    store = _make_store()
+    store._data = {}
+
+    cutoff_date = date.today() - timedelta(days=91)
+    recent_date = date.today().isoformat()
+    old_date = cutoff_date.isoformat()
+
+    store._data[old_date] = {"on_time_count": 1, "total_observations": 1}
+    store._data[recent_date] = {"on_time_count": 3, "total_observations": 3}
+
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value = date.today()
+        store._prune_old_entries()
+
+    assert old_date not in store._data
+    assert recent_date in store._data
+
+
+def test_get_rolling_stats_no_data():
+    """get_rolling_stats returns None values when there is no data."""
+    store = _make_store()
+    result = store.get_rolling_stats(7)
+    assert result["on_time_pct"] is None
+    assert result["avg_delay_minutes"] is None
+    assert result["days_with_data"] == 0
+
+
+def test_get_rolling_stats_with_data():
+    """get_rolling_stats aggregates correctly across multiple days."""
+    store = _make_store()
+    today = date.today()
+
+    store._data = {
+        (today - timedelta(days=0)).isoformat(): {
+            "on_time_count": 8, "delayed_count": 2, "cancelled_count": 0,
+            "total_observations": 10, "total_delay_minutes": 20,
+        },
+        (today - timedelta(days=1)).isoformat(): {
+            "on_time_count": 6, "delayed_count": 4, "cancelled_count": 0,
+            "total_observations": 10, "total_delay_minutes": 40,
+        },
+    }
+
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value = today
+        result = store.get_rolling_stats(7)
+
+    assert result["days_with_data"] == 2
+    assert result["on_time_pct"] == 70.0  # 14/20 * 100
+    assert result["avg_delay_minutes"] == 10.0  # 60 total delay / 6 delayed
+
+
+def test_get_rolling_stats_excludes_days_outside_window():
+    """get_rolling_stats only includes days within the requested window."""
+    store = _make_store()
+    today = date.today()
+
+    store._data = {
+        (today - timedelta(days=2)).isoformat(): {
+            "on_time_count": 5, "delayed_count": 0, "cancelled_count": 0,
+            "total_observations": 5, "total_delay_minutes": 0,
+        },
+        (today - timedelta(days=10)).isoformat(): {
+            "on_time_count": 1, "delayed_count": 9, "cancelled_count": 0,
+            "total_observations": 10, "total_delay_minutes": 90,
+        },
+    }
+
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value = today
+        result = store.get_rolling_stats(7)
+
+    assert result["days_with_data"] == 1
+    assert result["on_time_pct"] == 100.0
+
+
+def test_get_best_and_worst_days_no_data():
+    """get_best_and_worst_days returns None values when there is no data."""
+    store = _make_store()
+    result = store.get_best_and_worst_days(30)
+    assert result["worst_day"] is None
+    assert result["best_day"] is None
+
+
+def test_get_best_and_worst_days():
+    """get_best_and_worst_days identifies correct best and worst days."""
+    store = _make_store()
+    today = date.today()
+
+    good_day = (today - timedelta(days=1)).isoformat()
+    bad_day = (today - timedelta(days=2)).isoformat()
+
+    store._data = {
+        good_day: {"on_time_pct": 95.0, "avg_delay_minutes": 2.0, "total_observations": 10},
+        bad_day: {"on_time_pct": 30.0, "avg_delay_minutes": 15.0, "total_observations": 10},
+    }
+
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value = today
+        result = store.get_best_and_worst_days(30)
+
+    assert result["best_day"]["date"] == good_day
+    assert result["worst_day"]["date"] == bad_day
+
+
+def test_get_today_stats_empty():
+    """get_today_stats returns empty dict when no data for today."""
+    store = _make_store()
+    today = date.today()
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value.isoformat.return_value = (
+            today - timedelta(days=5)
+        ).isoformat()
+        result = store.get_today_stats()
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_on_time_pct_computed_correctly():
+    """on_time_pct is stored and computed correctly after recording."""
+    store = _make_store()
+    await store.async_load()
+    today = "2026-05-17"
+
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value.isoformat.return_value = today
+        await store.async_record_observation(_parsed_data(on_time=3, delayed=1, cancelled=0))
+
+    day = store._data[today]
+    assert day["on_time_pct"] == 75.0  # 3/4 * 100
+    assert day["avg_delay_minutes"] == 5.0  # 1 delayed service with 5 min delay

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -99,7 +99,7 @@ async def test_record_same_day_accumulates():
     assert day["on_time_count"] == 3
     assert day["delayed_count"] == 1
     assert day["cancelled_count"] == 1
-    assert day["total_observations"] == 6
+    assert day["total_observations"] == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Introduces CommuteStatisticsStore (statistics.py) which uses HA's Store
to persist daily on-time %, delay counts, and average delay across a
rolling 90-day window. The coordinator records an observation after each
successful API update; two new sensor entities (HistoricalReliabilitySensor
and HistoricalDelaysSensor) expose 7-day and 30-day rolling stats so users
can answer "is my commute typically reliable?"

https://claude.ai/code/session_01QuHLZt8T1juBv2HC8ib5nv