### PR TITLE
Add Get Historical Raw Data action

### DIFF
--- a/custom_components/my_rail_commute/__init__.py
+++ b/custom_components/my_rail_commute/__init__.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 import logging
 
+import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -20,6 +23,8 @@ from .const import (
 )
 from .coordinator import NationalRailDataUpdateCoordinator
 from .statistics import CommuteStatisticsStore
+
+SERVICE_GET_HISTORICAL_RAW_DATA = "get_historical_raw_data"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,6 +85,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Register update listener for options changes
         entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
+        # Register domain-wide service (only once across all entries)
+        if not hass.services.has_service(DOMAIN, SERVICE_GET_HISTORICAL_RAW_DATA):
+            async def _handle_get_historical_raw_data(call: ServiceCall) -> dict:
+                entry_id = call.data["entry_id"]
+                if entry_id not in hass.data.get(DOMAIN, {}):
+                    raise ServiceValidationError(
+                        f"No commute found with entry_id: {entry_id}"
+                    )
+                coordinator = hass.data[DOMAIN][entry_id]
+                return {"days": coordinator.stats_store.get_raw_data()}
+
+            hass.services.async_register(
+                DOMAIN,
+                SERVICE_GET_HISTORICAL_RAW_DATA,
+                _handle_get_historical_raw_data,
+                schema=vol.Schema({vol.Required("entry_id"): cv.string}),
+                supports_response=SupportsResponse.ONLY,
+            )
+
         _LOGGER.debug("My Rail Commute integration setup complete")
 
         return True
@@ -108,6 +132,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.api.close()
 
         hass.data[DOMAIN].pop(entry.entry_id)
+
+        # Remove domain-wide service when the last entry is unloaded
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_GET_HISTORICAL_RAW_DATA)
 
     return unload_ok
 

--- a/custom_components/my_rail_commute/services.yaml
+++ b/custom_components/my_rail_commute/services.yaml
@@ -111,3 +111,14 @@ clear_flagged:
       required: true
       selector:
         text: {}
+
+get_historical_raw_data:
+  name: Get Historical Raw Data
+  description: Retrieve the full raw historical daily statistics for a commute. Returns up to 90 days of per-day on-time and delay data.
+  fields:
+    entry_id:
+      name: Entry ID
+      description: The config entry ID of the commute (find it in Settings → Integrations).
+      required: true
+      selector:
+        text: {}

--- a/custom_components/my_rail_commute/statistics.py
+++ b/custom_components/my_rail_commute/statistics.py
@@ -143,6 +143,10 @@ class CommuteStatisticsStore:
             })
         return result
 
+    def get_raw_data(self) -> dict[str, Any]:
+        """Return a copy of all stored daily stats records."""
+        return dict(self._data)
+
     def _prune_old_entries(self) -> None:
         """Remove entries older than STATS_RETENTION_DAYS."""
         cutoff = (dt_util.now().date() - timedelta(days=STATS_RETENTION_DAYS)).isoformat()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,141 @@
+"""Tests for the get_historical_raw_data service action."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.my_rail_commute import (
+    SERVICE_GET_HISTORICAL_RAW_DATA,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.my_rail_commute.const import DOMAIN
+
+
+def _make_hass(entry_id="test_entry_id", raw_data=None):
+    """Build a minimal hass mock with one commute entry registered."""
+    if raw_data is None:
+        raw_data = {"2026-05-17": {"on_time_count": 5, "delayed_count": 1}}
+
+    stats_store = MagicMock()
+    stats_store.get_raw_data = MagicMock(return_value=raw_data)
+
+    coordinator = MagicMock()
+    coordinator.stats_store = stats_store
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry_id: coordinator}}
+    hass.services = MagicMock()
+    hass.services.has_service = MagicMock(return_value=True)
+
+    return hass, coordinator, stats_store
+
+
+class _FakeServiceCall:
+    def __init__(self, entry_id):
+        self.data = {"entry_id": entry_id}
+
+
+@pytest.mark.asyncio
+async def test_get_historical_raw_data_returns_days():
+    """Service handler returns a 'days' dict with all raw stats."""
+    raw_data = {"2026-05-17": {"on_time_count": 10, "delayed_count": 2}}
+    hass, coordinator, stats_store = _make_hass(raw_data=raw_data)
+
+    # Simulate calling the handler directly via the registered service
+    registered_handler = None
+
+    def capture_register(domain, service_name, handler, **kwargs):
+        nonlocal registered_handler
+        registered_handler = handler
+
+    hass.services.has_service = MagicMock(return_value=False)
+    hass.services.async_register = MagicMock(side_effect=capture_register)
+
+    # Build a minimal entry mock so async_setup_entry can run
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.data = {"api_key": "test_key", "origin": "PAD", "destination": "RDG",
+                  "time_window": 60, "num_services": 3, "night_updates": False,
+                  "severe_delay_threshold": 15, "major_delay_threshold": 10,
+                  "minor_delay_threshold": 3, "departed_train_grace_period": 5}
+    entry.options = {}
+
+    with (
+        patch("custom_components.my_rail_commute.async_get_clientsession"),
+        patch("custom_components.my_rail_commute.NationalRailAPI"),
+        patch("custom_components.my_rail_commute.NationalRailDataUpdateCoordinator") as MockCoord,
+        patch("custom_components.my_rail_commute.CommuteStatisticsStore") as MockStore,
+    ):
+        mock_coord_instance = MagicMock()
+        mock_coord_instance.stats_store = stats_store
+        mock_coord_instance.async_config_entry_first_refresh = AsyncMock()
+        MockCoord.return_value = mock_coord_instance
+
+        mock_store_instance = MagicMock()
+        mock_store_instance.async_load = AsyncMock()
+        mock_store_instance.get_raw_data = MagicMock(return_value=raw_data)
+        MockStore.return_value = mock_store_instance
+
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        hass.data = {}
+
+        await async_setup_entry(hass, entry)
+
+    assert registered_handler is not None
+    call = _FakeServiceCall("test_entry_id")
+    result = await registered_handler(call)
+    assert "days" in result
+    assert result["days"] == raw_data
+
+
+@pytest.mark.asyncio
+async def test_get_historical_raw_data_invalid_entry_id():
+    """Service handler raises ServiceValidationError for unknown entry_id."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    hass, _, _ = _make_hass(entry_id="real_entry")
+
+    registered_handler = None
+
+    def capture_register(domain, service_name, handler, **kwargs):
+        nonlocal registered_handler
+        registered_handler = handler
+
+    hass.services.has_service = MagicMock(return_value=False)
+    hass.services.async_register = MagicMock(side_effect=capture_register)
+
+    entry = MagicMock()
+    entry.entry_id = "real_entry"
+    entry.data = {"api_key": "test_key", "origin": "PAD", "destination": "RDG",
+                  "time_window": 60, "num_services": 3, "night_updates": False,
+                  "severe_delay_threshold": 15, "major_delay_threshold": 10,
+                  "minor_delay_threshold": 3, "departed_train_grace_period": 5}
+    entry.options = {}
+
+    with (
+        patch("custom_components.my_rail_commute.async_get_clientsession"),
+        patch("custom_components.my_rail_commute.NationalRailAPI"),
+        patch("custom_components.my_rail_commute.NationalRailDataUpdateCoordinator") as MockCoord,
+        patch("custom_components.my_rail_commute.CommuteStatisticsStore") as MockStore,
+    ):
+        mock_coord_instance = MagicMock()
+        mock_coord_instance.async_config_entry_first_refresh = AsyncMock()
+        MockCoord.return_value = mock_coord_instance
+
+        mock_store_instance = MagicMock()
+        mock_store_instance.async_load = AsyncMock()
+        MockStore.return_value = mock_store_instance
+
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        hass.data = {}
+
+        await async_setup_entry(hass, entry)
+
+    assert registered_handler is not None
+    call = _FakeServiceCall("nonexistent_entry_id")
+    with pytest.raises(ServiceValidationError):
+        await registered_handler(call)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -252,3 +252,20 @@ async def test_on_time_pct_computed_correctly():
     day = store._data[today]
     assert day["on_time_pct"] == 75.0  # 3/4 * 100
     assert day["avg_delay_minutes"] == 5.0  # 1 delayed service with 5 min delay
+
+
+def test_get_raw_data_returns_copy():
+    """get_raw_data returns all stored daily records as a copy."""
+    store = _make_store()
+    store._data = {"2026-05-17": {"on_time_count": 5}}
+    result = store.get_raw_data()
+    assert result == {"2026-05-17": {"on_time_count": 5}}
+    # Mutating the result must not affect internal state
+    result["2026-05-18"] = {}
+    assert "2026-05-18" not in store._data
+
+
+def test_get_raw_data_empty():
+    """get_raw_data returns empty dict when no data has been recorded."""
+    store = _make_store()
+    assert store.get_raw_data() == {}

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "my-rail-commute"
+version = "1.1.4"
+source = { virtual = "." }


### PR DESCRIPTION
Registers a new HA service action `get_historical_raw_data` that returns
the full 90-day raw daily statistics store for a given commute entry.
Uses SupportsResponse.ONLY so callers can capture the result via
response_variable in automations and scripts.

https://claude.ai/code/session_0117yW8nX2fyetfZ1G9bZV4F