### PR TITLE
Add multi-destination departures support (all departures from origin)

### DIFF
--- a/custom_components/my_rail_commute/api.py
+++ b/custom_components/my_rail_commute/api.py
@@ -341,7 +341,7 @@ class NationalRailAPI:
     async def get_departure_board(
         self,
         origin_crs: str,
-        destination_crs: str,
+        destination_crs: str | None = None,
         time_window: int = 60,
         num_rows: int = 10,
     ) -> dict[str, Any]:
@@ -349,7 +349,7 @@ class NationalRailAPI:
 
         Args:
             origin_crs: Origin station CRS code (3 letters)
-            destination_crs: Destination station CRS code (3 letters)
+            destination_crs: Destination station CRS code (3 letters), or None for all departures
             time_window: Time window in minutes
             num_rows: Number of services to retrieve
 
@@ -363,18 +363,19 @@ class NationalRailAPI:
         _LOGGER.debug(
             "Fetching departure board: %s -> %s (window: %s mins, rows: %s)",
             origin_crs,
-            destination_crs,
+            destination_crs or "ALL",
             time_window,
             num_rows,
         )
 
         # Use path parameters for the CRS code and query parameters for filters
         endpoint = f"GetDepBoardWithDetails/{origin_crs.upper()}"
-        params = {
-            "filterCrs": destination_crs.upper(),
+        params: dict[str, Any] = {
             "timeWindow": time_window,
             "numRows": num_rows,
         }
+        if destination_crs:
+            params["filterCrs"] = destination_crs.upper()
 
         try:
             data = await self._request(endpoint, params)
@@ -398,7 +399,7 @@ class NationalRailAPI:
         board = data.get("GetStationBoardResult", data)
 
         location_name = board.get("locationName", "Unknown")
-        destination_name = board.get("filterLocationName", "Unknown")
+        destination_name = board.get("filterLocationName") or None
 
         # Extract services
         train_services = board.get("trainServices", {})

--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -324,18 +324,18 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._destination_name = None
                     self._all_departures = True
                 else:
-                    destination = user_input.get(CONF_DESTINATION, "").strip().upper()
+                    destination = user_input.get(CONF_DESTINATION, "").strip()
                     if not destination:
                         errors[CONF_DESTINATION] = "required"
                         raise ValueError("destination_required")
 
-                    # Validate both stations
+                    # Validate both stations (destination passed as-is, matching original behaviour)
                     station_info = await validate_stations(
                         self.hass, self._api_key, origin, destination
                     )
 
                     self._origin = origin
-                    self._destination = destination
+                    self._destination = destination.upper()  # normalise after validation
                     self._origin_name = station_info["origin_name"]
                     self._destination_name = station_info["destination_name"]
                     self._all_departures = False

--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -24,6 +24,7 @@ from .api import (
 )
 from .const import (
     CONF_ADD_RETURN_JOURNEY,
+    CONF_ALL_DEPARTURES,
     CONF_COMMUTE_NAME,
     CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
@@ -185,6 +186,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._destination: str | None = None
         self._origin_name: str | None = None
         self._destination_name: str | None = None
+        self._all_departures: bool = False
         self._commute_name: str | None = None
         self._time_window: int | None = None
         self._num_services: int | None = None
@@ -306,22 +308,43 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 origin = user_input[CONF_ORIGIN].strip().upper()
-                destination = user_input[CONF_DESTINATION]
+                all_departures = bool(user_input.get(CONF_ALL_DEPARTURES, False))
 
-                # Validate stations
-                station_info = await validate_stations(
-                    self.hass, self._api_key, origin, destination
-                )
+                if all_departures:
+                    # Validate only the origin station
+                    session = async_get_clientsession(self.hass)
+                    api = NationalRailAPI(self._api_key, session)
+                    origin_name = await api.validate_station(origin)
+                    if not origin_name:
+                        raise InvalidStationError("Could not validate origin station")
 
-                self._origin = origin
-                self._destination = destination.strip().upper()
-                self._origin_name = station_info["origin_name"]
-                self._destination_name = station_info["destination_name"]
+                    self._origin = origin
+                    self._destination = None
+                    self._origin_name = origin_name
+                    self._destination_name = None
+                    self._all_departures = True
+                else:
+                    destination = user_input.get(CONF_DESTINATION, "").strip().upper()
+                    if not destination:
+                        errors[CONF_DESTINATION] = "required"
+                        raise ValueError("destination_required")
+
+                    # Validate both stations
+                    station_info = await validate_stations(
+                        self.hass, self._api_key, origin, destination
+                    )
+
+                    self._origin = origin
+                    self._destination = destination
+                    self._origin_name = station_info["origin_name"]
+                    self._destination_name = station_info["destination_name"]
+                    self._all_departures = False
 
                 return await self.async_step_settings()
 
-            except ValueError:
-                errors["base"] = "same_station"
+            except ValueError as err:
+                if "destination_required" not in str(err):
+                    errors["base"] = "same_station"
             except InvalidStationError:
                 errors["base"] = "invalid_station"
             except AuthenticationError:
@@ -354,7 +377,8 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_ORIGIN): origin_field,
-                vol.Required(CONF_DESTINATION): str,
+                vol.Optional(CONF_ALL_DEPARTURES, default=False): selector.BooleanSelector(),
+                vol.Optional(CONF_DESTINATION): str,
             }
         )
 
@@ -391,10 +415,11 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not errors:
                 # Store settings in instance variables
-                self._commute_name = user_input.get(
-                    CONF_COMMUTE_NAME,
-                    f"{self._origin_name} to {self._destination_name}",
-                )
+                if self._all_departures:
+                    default_name = f"Departures from {self._origin_name}"
+                else:
+                    default_name = f"{self._origin_name} to {self._destination_name}"
+                self._commute_name = user_input.get(CONF_COMMUTE_NAME, default_name)
                 self._time_window = user_input[CONF_TIME_WINDOW]
                 self._num_services = user_input[CONF_NUM_SERVICES]
                 self._night_updates = user_input[CONF_NIGHT_UPDATES]
@@ -405,16 +430,25 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD
                 )
 
-                # Set unique ID based on route
-                await self.async_set_unique_id(
-                    f"{self._origin}_{self._destination}"
-                )
+                # Set unique ID based on route (all-departures gets a distinct suffix)
+                if self._all_departures:
+                    unique_id = f"{self._origin}_all_departures"
+                else:
+                    unique_id = f"{self._origin}_{self._destination}"
+                await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
+
+                # Skip return-journey step when showing all departures
+                if self._all_departures:
+                    return self._create_entry()
 
                 return await self.async_step_return_journey()
 
         # Default commute name
-        default_name = f"{self._origin_name} to {self._destination_name}"
+        if self._all_departures:
+            default_name = f"Departures from {self._origin_name}"
+        else:
+            default_name = f"{self._origin_name} to {self._destination_name}"
 
         data_schema = vol.Schema(
             {
@@ -506,7 +540,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={
                 "origin": self._origin_name,
-                "destination": self._destination_name,
+                "destination": self._destination_name or "All destinations",
             },
         )
 
@@ -591,22 +625,22 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _create_entry(self) -> FlowResult:
         """Create the config entry using stored instance variables."""
-        return self.async_create_entry(
-            title=self._commute_name,
-            data={
-                CONF_API_KEY: self._api_key,
-                CONF_ORIGIN: self._origin,
-                CONF_DESTINATION: self._destination,
-                CONF_COMMUTE_NAME: self._commute_name,
-                CONF_TIME_WINDOW: self._time_window,
-                CONF_NUM_SERVICES: self._num_services,
-                CONF_NIGHT_UPDATES: self._night_updates,
-                CONF_SEVERE_DELAY_THRESHOLD: self._severe_delay_threshold,
-                CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
-                CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
-                CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
-            },
-        )
+        data: dict[str, Any] = {
+            CONF_API_KEY: self._api_key,
+            CONF_ORIGIN: self._origin,
+            CONF_ALL_DEPARTURES: self._all_departures,
+            CONF_COMMUTE_NAME: self._commute_name,
+            CONF_TIME_WINDOW: self._time_window,
+            CONF_NUM_SERVICES: self._num_services,
+            CONF_NIGHT_UPDATES: self._night_updates,
+            CONF_SEVERE_DELAY_THRESHOLD: self._severe_delay_threshold,
+            CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
+            CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
+            CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
+        }
+        if self._destination:
+            data[CONF_DESTINATION] = self._destination
+        return self.async_create_entry(title=self._commute_name, data=data)
 
     @staticmethod
     @callback

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -17,6 +17,7 @@ CONF_MAJOR_DELAY_THRESHOLD: Final = "major_delay_threshold"
 CONF_MINOR_DELAY_THRESHOLD: Final = "minor_delay_threshold"
 CONF_DEPARTED_TRAIN_GRACE_PERIOD: Final = "departed_train_grace_period"
 CONF_ADD_RETURN_JOURNEY: Final = "add_return_journey"
+CONF_ALL_DEPARTURES: Final = "all_departures"
 
 # Legacy config keys (for migration)
 CONF_DISRUPTION_SINGLE_DELAY: Final = "disruption_single_delay"

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.util import dt as dt_util
 
 from .api import NationalRailAPI, NationalRailAPIError
 from .const import (
+    CONF_ALL_DEPARTURES,
     CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
     CONF_DISRUPTION_MULTIPLE_COUNT,
@@ -75,7 +76,8 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Get configuration
         self.origin = config[CONF_ORIGIN]
-        self.destination = config[CONF_DESTINATION]
+        self.destination = config.get(CONF_DESTINATION)  # None when all_departures=True
+        self.all_departures = config.get(CONF_ALL_DEPARTURES, False)
         self.time_window = int(config[CONF_TIME_WINDOW])
         self.num_services = int(config[CONF_NUM_SERVICES])
         self.night_updates_enabled = config.get(CONF_NIGHT_UPDATES, False)
@@ -175,7 +177,11 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         Raises:
             UpdateFailed: If update fails
         """
-        _LOGGER.debug("Starting data update for %s -> %s", self.origin, self.destination)
+        _LOGGER.debug(
+            "Starting data update for %s -> %s",
+            self.origin,
+            self.destination or "ALL",
+        )
 
         # Update interval may have changed (e.g., switching between peak/off-peak/night)
         # Use async lock to prevent race conditions with concurrent updates
@@ -189,15 +195,18 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(
                 "Fetching departure data for %s -> %s",
                 self.origin,
-                self.destination,
+                self.destination or "ALL",
             )
+
+            # When showing all departures, fetch enough rows to populate multiple destinations
+            num_rows = max(self.num_services, 20) if self.all_departures else self.num_services
 
             # Fetch departure board
             data = await self.api.get_departure_board(
                 self.origin,
-                self.destination,
-                self.time_window,
-                self.num_services,
+                destination_crs=self.destination,
+                time_window=self.time_window,
+                num_rows=num_rows,
             )
 
             # Store station names
@@ -334,6 +343,38 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         return filtered_services
 
+    def _build_services_by_destination(self, services: list[dict[str, Any]]) -> dict[str, Any]:
+        """Group services by their destination and compute per-destination status.
+
+        Args:
+            services: Flat list of service data
+
+        Returns:
+            Dict keyed by destination name, each entry containing services + status counts
+        """
+        groups: dict[str, Any] = {}
+        for svc in services:
+            dest = svc.get("destination") or "Unknown"
+            if dest not in groups:
+                groups[dest] = {
+                    "services": [],
+                    "on_time_count": 0,
+                    "delayed_count": 0,
+                    "cancelled_count": 0,
+                }
+            groups[dest]["services"].append(svc)
+            if svc.get("is_cancelled"):
+                groups[dest]["cancelled_count"] += 1
+            elif svc.get("status") == STATUS_DELAYED:
+                groups[dest]["delayed_count"] += 1
+            else:
+                groups[dest]["on_time_count"] += 1
+
+        for dest_data in groups.values():
+            dest_data["status"] = self._calculate_overall_status(dest_data["services"])
+
+        return groups
+
     def _parse_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Parse and enrich API data.
 
@@ -369,7 +410,10 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         delay_info = self._collect_delay_info(services)
 
         # Build summary
-        summary = self._build_summary(on_time_count, delayed_count, cancelled_count)
+        if self.all_departures:
+            summary = self._build_all_departures_summary(len(services), on_time_count, delayed_count, cancelled_count)
+        else:
+            summary = self._build_summary(on_time_count, delayed_count, cancelled_count)
 
         # Get next train (first non-cancelled service)
         next_train = None
@@ -378,11 +422,11 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 next_train = service
                 break
 
-        return {
+        result: dict[str, Any] = {
             "origin": self.origin,
             "origin_name": self.origin_name or self.origin,
             "destination": self.destination,
-            "destination_name": self.destination_name or self.destination,
+            "destination_name": self.destination_name,
             "time_window": self.time_window,
             "services_tracked": len(services),
             "total_services_found": len(data.get("services", [])),
@@ -395,10 +439,16 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             "max_delay_minutes": delay_info["max_delay_minutes"],
             "disruption_reasons": delay_info["disruption_reasons"],
             "summary": summary,
+            "multi_destination": self.all_departures,
             "last_updated": dt_util.now().isoformat(),
             "next_update": (dt_util.now() + self.update_interval).isoformat(),
             "nrcc_messages": data.get("nrcc_messages", []),
         }
+
+        if self.all_departures:
+            result["services_by_destination"] = self._build_services_by_destination(services)
+
+        return result
 
     def _collect_delay_info(self, services: list[dict[str, Any]]) -> dict[str, Any]:
         """Collect delay information for display attributes.
@@ -520,3 +570,31 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         # All on time
         return f"{on_time_count} train{'s' if on_time_count != 1 else ''} on time"
+
+    def _build_all_departures_summary(
+        self, total: int, on_time_count: int, delayed_count: int, cancelled_count: int
+    ) -> str:
+        """Build summary text for all-departures mode.
+
+        Args:
+            total: Total number of services
+            on_time_count: Number of on-time services
+            delayed_count: Number of delayed services
+            cancelled_count: Number of cancelled services
+
+        Returns:
+            Summary string for all departures from this origin
+        """
+        if total == 0:
+            return f"No departures from {self.origin_name or self.origin}"
+
+        issues = []
+        if cancelled_count:
+            issues.append(f"{cancelled_count} cancelled")
+        if delayed_count:
+            issues.append(f"{delayed_count} delayed")
+
+        if issues:
+            return f"{total} departure{'s' if total != 1 else ''} from {self.origin_name or self.origin} — {', '.join(issues)}"
+
+        return f"{total} departure{'s' if total != 1 else ''} from {self.origin_name or self.origin}"

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -99,7 +99,7 @@ async def async_setup_entry(
         "Setting up %d sensor entities for %s -> %s",
         len(entities),
         coordinator.origin,
-        coordinator.destination,
+        coordinator.destination or "ALL",
     )
 
     async_add_entities(entities)
@@ -129,8 +129,9 @@ class NationalRailCommuteEntity(CoordinatorEntity[NationalRailDataUpdateCoordina
         origin = coordinator.origin
         destination = coordinator.destination
 
+        device_id = f"{origin}_{destination}" if destination else f"{origin}_all_departures"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{origin}_{destination}")},
+            identifiers={(DOMAIN, device_id)},
             name=commute_name,
             manufacturer="National Rail",
             model="Live Departure Board",
@@ -199,6 +200,7 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
                 "calling_points": service.get("calling_points", []),
                 "estimated_arrival": service.get("estimated_arrival"),
                 "scheduled_arrival": service.get("scheduled_arrival"),
+                "destination": service.get("destination"),
             }
 
             # Add optional fields if present
@@ -209,7 +211,7 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
 
             all_trains.append(train_data)
 
-        return {
+        attrs: dict[str, Any] = {
             ATTR_ORIGIN: data.get("origin"),
             ATTR_ORIGIN_NAME: data.get("origin_name"),
             ATTR_DESTINATION: data.get("destination"),
@@ -225,6 +227,12 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
             "next_update": data.get("next_update"),
             "all_trains": all_trains,  # Complete train data for custom cards
         }
+
+        if data.get("multi_destination"):
+            attrs["multi_destination"] = True
+            attrs["services_by_destination"] = data.get("services_by_destination", {})
+
+        return attrs
 
 
 class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -10,10 +10,11 @@
       },
       "stations": {
         "title": "Configure Route",
-        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enter the destination station CRS code.",
+        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enable 'All Departures' to show every train from this station, or enter a destination CRS code to track a specific route.",
         "data": {
           "origin": "Origin Station",
-          "destination": "Destination Station (CRS Code)"
+          "all_departures": "Show All Departures (no destination filter)",
+          "destination": "Destination Station (CRS Code) — leave blank if 'All Departures' is enabled"
         }
       },
       "settings": {

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -10,10 +10,11 @@
       },
       "stations": {
         "title": "Configure Route",
-        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enter the destination station CRS code.",
+        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enable 'All Departures' to show every train from this station, or enter a destination CRS code to track a specific route.",
         "data": {
           "origin": "Origin Station",
-          "destination": "Destination Station (CRS Code)"
+          "all_departures": "Show All Departures (no destination filter)",
+          "destination": "Destination Station (CRS Code) — leave blank if 'All Departures' is enabled"
         }
       },
       "settings": {


### PR DESCRIPTION
Introduces an optional "All Departures" mode that removes the destination
filter and shows every departure from the configured origin station, grouped
by final destination in the Lovelace card.

Backend changes:
- const.py: Add CONF_ALL_DEPARTURES constant
- api.py: Make destination_crs optional in get_departure_board; omit
  filterCrs param when None so the API returns all services
- coordinator.py: Handle optional destination; build services_by_destination
  dict with per-destination status; use larger num_rows (min 20) for all-
  departures mode; add multi_destination flag and all-departures summary text
- config_flow.py: Add all_departures boolean toggle on the stations step;
  when enabled, skip destination field and return-journey offer; use distinct
  unique ID (origin_all_departures) to avoid collision with route entries
- sensor.py: Expose multi_destination and services_by_destination attributes
  on CommuteSummarySensor; include destination field in each all_trains entry
- strings.json / en.json: Add label for the new all_departures toggle

https://claude.ai/code/session_015j49iQAwKvb3vDxab5NQuU