### PR TITLE
fix(sensor): expose reverse route stats on CommuteSummarySensor

### DIFF
--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -1,4 +1,5 @@
 """Constants for the My Rail Commute integration."""
+
 from datetime import timedelta
 from typing import Final
 
@@ -25,7 +26,9 @@ CONF_DISRUPTION_MULTIPLE_DELAY: Final = "disruption_multiple_delay"
 CONF_DISRUPTION_MULTIPLE_COUNT: Final = "disruption_multiple_count"
 
 # API Configuration
-API_BASE_URL: Final = "https://api1.raildata.org.uk/1010-live-departure-board-dep1_2/LDBWS/api/20220120"
+API_BASE_URL: Final = (
+    "https://api1.raildata.org.uk/1010-live-departure-board-dep1_2/LDBWS/api/20220120"
+)
 API_TIMEOUT: Final = 30
 
 # Default values
@@ -123,7 +126,9 @@ ATTR_DISRUPTION_REASONS: Final = "disruption_reasons"
 
 # API Error Messages
 ERROR_AUTH: Final = "Authentication failed. Please check your API key."
-ERROR_INVALID_STATION: Final = "Invalid station code. Please use a valid 3-letter CRS code."
+ERROR_INVALID_STATION: Final = (
+    "Invalid station code. Please use a valid 3-letter CRS code."
+)
 ERROR_NO_SERVICES: Final = "No services found for this route."
 ERROR_API_UNAVAILABLE: Final = "Rail API is currently unavailable."
 ERROR_RATE_LIMIT: Final = "API rate limit exceeded. Retrying later."
@@ -149,3 +154,12 @@ ATTR_ON_TIME_COUNT_TODAY: Final = "on_time_count_today"
 ATTR_DELAYED_COUNT_TODAY: Final = "delayed_count_today"
 ATTR_CANCELLED_COUNT_TODAY: Final = "cancelled_count_today"
 ATTR_DAILY_BREAKDOWN: Final = "daily_breakdown"
+
+# Reverse-route stats attributes (exposed on CommuteSummarySensor for the paired direction)
+ATTR_REVERSE_ON_TIME_PCT_TODAY: Final = "reverse_on_time_pct_today"
+ATTR_REVERSE_ON_TIME_PCT_7D: Final = "reverse_on_time_pct_7day"
+ATTR_REVERSE_ON_TIME_PCT_30D: Final = "reverse_on_time_pct_30day"
+ATTR_REVERSE_AVG_DELAY_7D: Final = "reverse_avg_delay_7day"
+ATTR_REVERSE_WORST_DAY: Final = "reverse_worst_day"
+ATTR_REVERSE_BEST_DAY: Final = "reverse_best_day"
+ATTR_REVERSE_DAILY_BREAKDOWN: Final = "reverse_daily_breakdown"

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for My Rail Commute integration."""
+
 from __future__ import annotations
 
 import logging
@@ -10,17 +11,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import slugify
 
 from .const import (
     ATTR_AVG_DELAY_7D,
     ATTR_AVG_DELAY_TODAY,
     ATTR_BEST_DAY,
-    ATTR_DAILY_BREAKDOWN,
     ATTR_CALLING_POINTS,
     ATTR_CANCELLATION_REASON,
     ATTR_CANCELLED_COUNT,
     ATTR_CANCELLED_COUNT_TODAY,
+    ATTR_DAILY_BREAKDOWN,
     ATTR_DELAY_MINUTES,
     ATTR_DELAY_REASON,
     ATTR_DELAYED_COUNT,
@@ -32,13 +32,20 @@ from .const import (
     ATTR_IS_CANCELLED,
     ATTR_ON_TIME_COUNT,
     ATTR_ON_TIME_COUNT_TODAY,
-    ATTR_ON_TIME_PCT_30D,
     ATTR_ON_TIME_PCT_7D,
+    ATTR_ON_TIME_PCT_30D,
     ATTR_ON_TIME_PCT_TODAY,
     ATTR_OPERATOR,
     ATTR_ORIGIN,
     ATTR_ORIGIN_NAME,
     ATTR_PLATFORM,
+    ATTR_REVERSE_AVG_DELAY_7D,
+    ATTR_REVERSE_BEST_DAY,
+    ATTR_REVERSE_DAILY_BREAKDOWN,
+    ATTR_REVERSE_ON_TIME_PCT_7D,
+    ATTR_REVERSE_ON_TIME_PCT_30D,
+    ATTR_REVERSE_ON_TIME_PCT_TODAY,
+    ATTR_REVERSE_WORST_DAY,
     ATTR_SCHEDULED_ARRIVAL,
     ATTR_SCHEDULED_DEPARTURE,
     ATTR_SERVICE_ID,
@@ -129,7 +136,9 @@ class NationalRailCommuteEntity(CoordinatorEntity[NationalRailDataUpdateCoordina
         origin = coordinator.origin
         destination = coordinator.destination
 
-        device_id = f"{origin}_{destination}" if destination else f"{origin}_all_departures"
+        device_id = (
+            f"{origin}_{destination}" if destination else f"{origin}_all_departures"
+        )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
             name=commute_name,
@@ -245,6 +254,38 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
             attrs[ATTR_BEST_DAY] = best_worst["best_day"]
             attrs[ATTR_DAILY_BREAKDOWN] = store.get_daily_breakdown(30)
 
+        # Expose the paired reverse route's stats so that a card configured with
+        # only this entity still has access to both directions' stats when toggled.
+        # Without this the card shows the forward stats for both directions because
+        # it reads from a fixed entity reference rather than switching on toggle.
+        if self.hass is not None and DOMAIN in self.hass.data:
+            rev_coordinator = next(
+                (
+                    c
+                    for c in self.hass.data[DOMAIN].values()
+                    if (
+                        isinstance(c, NationalRailDataUpdateCoordinator)
+                        and c is not self.coordinator
+                        and c.origin == self.coordinator.destination
+                        and c.destination == self.coordinator.origin
+                    )
+                ),
+                None,
+            )
+            if rev_coordinator is not None and rev_coordinator.stats_store is not None:
+                rev_store = rev_coordinator.stats_store
+                rev_today = rev_store.get_today_stats()
+                rev_7 = rev_store.get_rolling_stats(7)
+                rev_30 = rev_store.get_rolling_stats(30)
+                rev_bw = rev_store.get_best_and_worst_days(30)
+                attrs[ATTR_REVERSE_ON_TIME_PCT_TODAY] = rev_today.get("on_time_pct")
+                attrs[ATTR_REVERSE_ON_TIME_PCT_7D] = rev_7["on_time_pct"]
+                attrs[ATTR_REVERSE_ON_TIME_PCT_30D] = rev_30["on_time_pct"]
+                attrs[ATTR_REVERSE_AVG_DELAY_7D] = rev_7["avg_delay_minutes"]
+                attrs[ATTR_REVERSE_WORST_DAY] = rev_bw["worst_day"]
+                attrs[ATTR_REVERSE_BEST_DAY] = rev_bw["best_day"]
+                attrs[ATTR_REVERSE_DAILY_BREAKDOWN] = rev_store.get_daily_breakdown(30)
+
         if data.get("multi_destination"):
             attrs["multi_destination"] = True
             attrs["services_by_destination"] = data.get("services_by_destination", {})
@@ -341,12 +382,14 @@ class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):
         total_trains = len(services)
         cancelled_count = sum(1 for s in services if s.get("is_cancelled", False))
         major_delays = sum(
-            1 for s in services
+            1
+            for s in services
             if not s.get("is_cancelled", False)
             and s.get("delay_minutes", 0) >= self.coordinator.major_delay_threshold
         )
         minor_delays = sum(
-            1 for s in services
+            1
+            for s in services
             if not s.get("is_cancelled", False)
             and s.get("delay_minutes", 0) >= self.coordinator.minor_delay_threshold
             and s.get("delay_minutes", 0) < self.coordinator.major_delay_threshold
@@ -357,8 +400,12 @@ class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):
         max_delay = 0
         if services:
             max_delay = max(
-                (s.get("delay_minutes", 0) for s in services if not s.get("is_cancelled", False)),
-                default=0
+                (
+                    s.get("delay_minutes", 0)
+                    for s in services
+                    if not s.get("is_cancelled", False)
+                ),
+                default=0,
             )
 
         return {
@@ -368,7 +415,8 @@ class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):
             "major_delays_count": major_delays,
             "cancelled_count": cancelled_count,
             "max_delay_minutes": max_delay,
-            "disruption_threshold_met": data.get("overall_status", STATUS_NORMAL) != STATUS_NORMAL,
+            "disruption_threshold_met": data.get("overall_status", STATUS_NORMAL)
+            != STATUS_NORMAL,
             ATTR_ORIGIN: data.get("origin"),
             ATTR_ORIGIN_NAME: data.get("origin_name"),
             ATTR_DESTINATION: data.get("destination"),
@@ -432,7 +480,9 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
 
             # Validate service_id is not empty/None before tracking
             # Empty or None service_id cannot be reliably used for platform change detection
-            if not current_service_id or (isinstance(current_service_id, str) and not current_service_id.strip()):
+            if not current_service_id or (
+                isinstance(current_service_id, str) and not current_service_id.strip()
+            ):
                 # Invalid service_id - reset tracking and skip platform change detection
                 _LOGGER.debug(
                     "Train %d: Invalid service_id (empty/None), skipping platform tracking",
@@ -441,7 +491,10 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
                 self._platform_changed = False
                 self._previous_platform = None
                 self._current_service_id = None
-            elif self._current_service_id and current_service_id == self._current_service_id:
+            elif (
+                self._current_service_id
+                and current_service_id == self._current_service_id
+            ):
                 # Same service - check for platform change
                 if self._previous_platform != current_platform:
                     if self._previous_platform is not None:
@@ -564,7 +617,9 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
             ATTR_EXPECTED_DEPARTURE: train.get("expected_departure"),
             ATTR_PLATFORM: train.get("platform"),
             "platform_changed": self._platform_changed,
-            "previous_platform": self._previous_platform if self._platform_changed else None,
+            "previous_platform": self._previous_platform
+            if self._platform_changed
+            else None,
             ATTR_OPERATOR: train.get("operator"),
             ATTR_SERVICE_ID: train.get("service_id"),
             ATTR_STATUS: train.get("status"),
@@ -656,7 +711,9 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
 
             # Validate service_id is not empty/None before tracking
             # Empty or None service_id cannot be reliably used for platform change detection
-            if not current_service_id or (isinstance(current_service_id, str) and not current_service_id.strip()):
+            if not current_service_id or (
+                isinstance(current_service_id, str) and not current_service_id.strip()
+            ):
                 # Invalid service_id - reset tracking and skip platform change detection
                 _LOGGER.debug(
                     "Next train: Invalid service_id (empty/None), skipping platform tracking",
@@ -664,7 +721,10 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
                 self._platform_changed = False
                 self._previous_platform = None
                 self._current_service_id = None
-            elif self._current_service_id and current_service_id == self._current_service_id:
+            elif (
+                self._current_service_id
+                and current_service_id == self._current_service_id
+            ):
                 # Same service - check for platform change
                 if self._previous_platform != current_platform:
                     if self._previous_platform is not None:
@@ -784,7 +844,9 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
             ATTR_EXPECTED_DEPARTURE: train.get("expected_departure"),
             ATTR_PLATFORM: train.get("platform"),
             "platform_changed": self._platform_changed,
-            "previous_platform": self._previous_platform if self._platform_changed else None,
+            "previous_platform": self._previous_platform
+            if self._platform_changed
+            else None,
             ATTR_OPERATOR: train.get("operator"),
             ATTR_SERVICE_ID: train.get("service_id"),
             ATTR_STATUS: train.get("status"),

--- a/tests/test_sensor_summary_stats.py
+++ b/tests/test_sensor_summary_stats.py
@@ -11,19 +11,34 @@ from custom_components.my_rail_commute.const import (
     ATTR_ON_TIME_PCT_7D,
     ATTR_ON_TIME_PCT_30D,
     ATTR_ON_TIME_PCT_TODAY,
+    ATTR_REVERSE_AVG_DELAY_7D,
+    ATTR_REVERSE_BEST_DAY,
+    ATTR_REVERSE_DAILY_BREAKDOWN,
+    ATTR_REVERSE_ON_TIME_PCT_7D,
+    ATTR_REVERSE_ON_TIME_PCT_30D,
+    ATTR_REVERSE_ON_TIME_PCT_TODAY,
+    ATTR_REVERSE_WORST_DAY,
     ATTR_WORST_DAY,
+    DOMAIN,
+)
+from custom_components.my_rail_commute.coordinator import (
+    NationalRailDataUpdateCoordinator,
 )
 from custom_components.my_rail_commute.sensor import CommuteSummarySensor
 
 
-def _make_sensor(stats_store=None):
-    """Return a CommuteSummarySensor backed by a minimal mock coordinator."""
-    coordinator = MagicMock()
+def _make_coordinator(origin="LBG", destination="WYT", stats_store=None):
+    """Return a mock NationalRailDataUpdateCoordinator."""
+    coordinator = MagicMock(spec=NationalRailDataUpdateCoordinator)
+    coordinator.origin = origin
+    coordinator.destination = destination
+    coordinator.num_services = 3
+    coordinator.stats_store = stats_store
     coordinator.data = {
-        "origin": "LBG",
-        "origin_name": "London Bridge",
-        "destination": "WYT",
-        "destination_name": "Whyteleafe",
+        "origin": origin,
+        "origin_name": "London Bridge" if origin == "LBG" else "Whyteleafe",
+        "destination": destination,
+        "destination_name": "Whyteleafe" if destination == "WYT" else "London Bridge",
         "time_window": 60,
         "services_tracked": 2,
         "total_services_found": 2,
@@ -46,21 +61,37 @@ def _make_sensor(stats_store=None):
                 "calling_points": [],
                 "estimated_arrival": None,
                 "scheduled_arrival": None,
-                "destination": "Whyteleafe",
+                "destination": destination,
             },
         ],
     }
-    coordinator.num_services = 3
-    coordinator.stats_store = stats_store
+    return coordinator
+
+
+def _make_sensor(stats_store=None, hass_domain_data=None):
+    """Return a (sensor, coordinator) pair.
+
+    hass_domain_data: optional dict for hass.data[DOMAIN].  Defaults to an
+    empty dict so no reverse coordinator is found.  The sensor's own
+    coordinator is NOT automatically included — the `c is not self.coordinator`
+    guard in extra_state_attributes prevents it from being matched as its own
+    reverse anyway.
+    """
+    coordinator = _make_coordinator(
+        origin="LBG", destination="WYT", stats_store=stats_store
+    )
 
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.data = {"commute_name": "Test Commute"}
 
     sensor = CommuteSummarySensor(coordinator, entry)
-    sensor.hass = MagicMock()
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: hass_domain_data if hass_domain_data is not None else {}}
+    sensor.hass = hass
     sensor.async_write_ha_state = MagicMock()
-    return sensor
+    return sensor, coordinator
 
 
 def _make_stats_store(
@@ -120,7 +151,7 @@ def _make_stats_store(
 def test_summary_includes_historical_stats_when_store_present():
     """CommuteSummarySensor attrs include historical stats when stats_store is set."""
     store = _make_stats_store()
-    sensor = _make_sensor(stats_store=store)
+    sensor, _ = _make_sensor(stats_store=store)
 
     attrs = sensor.extra_state_attributes
 
@@ -141,7 +172,7 @@ def test_summary_historical_stats_values_match_store():
         on_time_pct_30d=98.1,
         avg_delay_7d=3.4,
     )
-    sensor = _make_sensor(stats_store=store)
+    sensor, _ = _make_sensor(stats_store=store)
 
     attrs = sensor.extra_state_attributes
 
@@ -156,7 +187,7 @@ def test_summary_historical_stats_values_match_store():
 
 def test_summary_no_historical_stats_when_store_absent():
     """CommuteSummarySensor attrs omit historical stats when stats_store is None."""
-    sensor = _make_sensor(stats_store=None)
+    sensor, _ = _make_sensor(stats_store=None)
 
     attrs = sensor.extra_state_attributes
 
@@ -178,8 +209,8 @@ def test_summary_different_routes_expose_different_stats():
         on_time_pct_today=85.0, on_time_pct_7d=87.5, avg_delay_7d=6.2
     )
 
-    sensor_outbound = _make_sensor(stats_store=store_outbound)
-    sensor_return = _make_sensor(stats_store=store_return)
+    sensor_outbound, _ = _make_sensor(stats_store=store_outbound)
+    sensor_return, _ = _make_sensor(stats_store=store_return)
 
     attrs_out = sensor_outbound.extra_state_attributes
     attrs_ret = sensor_return.extra_state_attributes
@@ -189,3 +220,117 @@ def test_summary_different_routes_expose_different_stats():
     assert attrs_ret[ATTR_ON_TIME_PCT_TODAY] == 85.0
     assert attrs_out[ATTR_AVG_DELAY_7D] == 3.4
     assert attrs_ret[ATTR_AVG_DELAY_7D] == 6.2
+
+
+# ---------------------------------------------------------------------------
+# Reverse-route stats tests
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_stats_exposed_when_paired_coordinator_exists():
+    """CommuteSummarySensor exposes reverse_* stats when a paired reverse route is present."""
+    fwd_store = _make_stats_store(on_time_pct_today=97.19, avg_delay_7d=3.4)
+    rev_store = _make_stats_store(on_time_pct_today=85.0, avg_delay_7d=6.2)
+
+    rev_coordinator = _make_coordinator(
+        origin="WYT", destination="LBG", stats_store=rev_store
+    )
+    # Only include the reverse coordinator; the forward coordinator's identity
+    # is checked via `c is not self.coordinator` so it need not be in the dict.
+    sensor, _ = _make_sensor(
+        stats_store=fwd_store,
+        hass_domain_data={"entry_rev": rev_coordinator},
+    )
+
+    attrs = sensor.extra_state_attributes
+
+    assert ATTR_REVERSE_ON_TIME_PCT_TODAY in attrs
+    assert ATTR_REVERSE_ON_TIME_PCT_7D in attrs
+    assert ATTR_REVERSE_ON_TIME_PCT_30D in attrs
+    assert ATTR_REVERSE_AVG_DELAY_7D in attrs
+    assert ATTR_REVERSE_BEST_DAY in attrs
+    assert ATTR_REVERSE_WORST_DAY in attrs
+    assert ATTR_REVERSE_DAILY_BREAKDOWN in attrs
+
+
+def test_reverse_stats_values_match_paired_coordinators_store():
+    """Reverse-route stats come from the paired coordinator's stats_store, not the forward store."""
+    fwd_store = _make_stats_store(on_time_pct_today=97.19, avg_delay_7d=3.4)
+    rev_store = _make_stats_store(
+        on_time_pct_today=85.0,
+        on_time_pct_7d=87.5,
+        on_time_pct_30d=88.0,
+        avg_delay_7d=6.2,
+    )
+
+    rev_coordinator = _make_coordinator(
+        origin="WYT", destination="LBG", stats_store=rev_store
+    )
+    sensor, _ = _make_sensor(
+        stats_store=fwd_store,
+        hass_domain_data={"entry_rev": rev_coordinator},
+    )
+
+    attrs = sensor.extra_state_attributes
+
+    # Forward stats unchanged
+    assert attrs[ATTR_ON_TIME_PCT_TODAY] == 97.19
+    assert attrs[ATTR_AVG_DELAY_7D] == 3.4
+
+    # Reverse stats come from the reverse store
+    assert attrs[ATTR_REVERSE_ON_TIME_PCT_TODAY] == 85.0
+    assert attrs[ATTR_REVERSE_ON_TIME_PCT_7D] == 87.5
+    assert attrs[ATTR_REVERSE_ON_TIME_PCT_30D] == 88.0
+    assert attrs[ATTR_REVERSE_AVG_DELAY_7D] == 6.2
+    assert attrs[ATTR_REVERSE_BEST_DAY]["date"] == "2026-05-18"
+    assert attrs[ATTR_REVERSE_WORST_DAY]["date"] == "2026-05-17"
+    assert len(attrs[ATTR_REVERSE_DAILY_BREAKDOWN]) == 3
+
+
+def test_reverse_stats_absent_when_no_paired_coordinator():
+    """Reverse-route stats are not included when no matching reverse coordinator exists."""
+    fwd_store = _make_stats_store()
+    sensor, _ = _make_sensor(stats_store=fwd_store, hass_domain_data={})
+
+    attrs = sensor.extra_state_attributes
+
+    assert ATTR_REVERSE_ON_TIME_PCT_TODAY not in attrs
+    assert ATTR_REVERSE_ON_TIME_PCT_7D not in attrs
+    assert ATTR_REVERSE_AVG_DELAY_7D not in attrs
+    assert ATTR_REVERSE_DAILY_BREAKDOWN not in attrs
+
+
+def test_reverse_stats_absent_when_paired_coordinator_has_no_stats_store():
+    """Reverse-route stats are omitted when the paired coordinator has no stats_store."""
+    fwd_store = _make_stats_store()
+    rev_coordinator = _make_coordinator(
+        origin="WYT", destination="LBG", stats_store=None
+    )
+
+    sensor, _ = _make_sensor(
+        stats_store=fwd_store,
+        hass_domain_data={"entry_rev": rev_coordinator},
+    )
+
+    attrs = sensor.extra_state_attributes
+
+    assert ATTR_REVERSE_ON_TIME_PCT_TODAY not in attrs
+    assert ATTR_REVERSE_AVG_DELAY_7D not in attrs
+
+
+def test_coordinator_not_matched_as_its_own_reverse():
+    """The sensor's own coordinator is never used as its reverse, even if its origin/destination
+    are patched to match the reverse route."""
+    fwd_store = _make_stats_store()
+    sensor, own_coordinator = _make_sensor(stats_store=fwd_store, hass_domain_data={})
+
+    # Now place the sensor's own coordinator in hass.data and patch its CRS codes
+    # so it would satisfy the origin/destination check — the `c is not self.coordinator`
+    # guard must still prevent it from being matched.
+    own_coordinator.origin = "WYT"
+    own_coordinator.destination = "LBG"
+    sensor.hass.data[DOMAIN]["entry_self"] = own_coordinator
+
+    attrs = sensor.extra_state_attributes
+
+    assert ATTR_REVERSE_ON_TIME_PCT_TODAY not in attrs


### PR DESCRIPTION
The previous fix added stats to CommuteSummarySensor attributes, but
the screenshots show stats are still identical after toggling. The root
cause is that the card reads stats from the primary entity's attributes
even when displaying the reverse direction's trains — it doesn't switch
entities for the stats section.

CommuteSummarySensor now also discovers the paired reverse-route
coordinator (origin == my.destination && destination == my.origin) and
exposes its stats under reverse_* prefixed attributes:
  reverse_on_time_pct_today / 7day / 30day
  reverse_avg_delay_7day
  reverse_worst_day / best_day
  reverse_daily_breakdown

This gives the card access to both directions' stats from whichever
single entity it holds a reference to, so the correct stats are shown
regardless of which way the toggle is pointed.