### PR TITLE
fix(sensor): drop daily_breakdown from CommuteSummarySensor to stay w…

### DIFF
--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -231,6 +231,8 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
         # Include historical stats so the card can read them directly from this
         # entity without needing a separate lookup — critical for route-toggle to
         # show the correct stats for the active direction.
+        # daily_breakdown is intentionally omitted here (already on
+        # HistoricalReliabilitySensor) to keep attribute payload within HA's 16 KB limit.
         store = self.coordinator.stats_store
         if store is not None:
             today = store.get_today_stats()
@@ -243,7 +245,6 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
             attrs[ATTR_AVG_DELAY_7D] = rolling_7["avg_delay_minutes"]
             attrs[ATTR_WORST_DAY] = best_worst["worst_day"]
             attrs[ATTR_BEST_DAY] = best_worst["best_day"]
-            attrs[ATTR_DAILY_BREAKDOWN] = store.get_daily_breakdown(30)
 
         if data.get("multi_destination"):
             attrs["multi_destination"] = True

--- a/tests/test_sensor_summary_stats.py
+++ b/tests/test_sensor_summary_stats.py
@@ -8,8 +8,8 @@ from custom_components.my_rail_commute.const import (
     ATTR_AVG_DELAY_7D,
     ATTR_BEST_DAY,
     ATTR_DAILY_BREAKDOWN,
-    ATTR_ON_TIME_PCT_7D,
     ATTR_ON_TIME_PCT_30D,
+    ATTR_ON_TIME_PCT_7D,
     ATTR_ON_TIME_PCT_TODAY,
     ATTR_WORST_DAY,
 )
@@ -118,7 +118,7 @@ def _make_stats_store(
 
 
 def test_summary_includes_historical_stats_when_store_present():
-    """CommuteSummarySensor attrs include historical stats when stats_store is set."""
+    """CommuteSummarySensor attrs include summary stats but not daily_breakdown."""
     store = _make_stats_store()
     sensor = _make_sensor(stats_store=store)
 
@@ -130,7 +130,8 @@ def test_summary_includes_historical_stats_when_store_present():
     assert ATTR_AVG_DELAY_7D in attrs
     assert ATTR_BEST_DAY in attrs
     assert ATTR_WORST_DAY in attrs
-    assert ATTR_DAILY_BREAKDOWN in attrs
+    # daily_breakdown is omitted to stay within HA's 16 KB attribute limit
+    assert ATTR_DAILY_BREAKDOWN not in attrs
 
 
 def test_summary_historical_stats_values_match_store():
@@ -151,11 +152,11 @@ def test_summary_historical_stats_values_match_store():
     assert attrs[ATTR_AVG_DELAY_7D] == 3.4
     assert attrs[ATTR_BEST_DAY]["date"] == "2026-05-18"
     assert attrs[ATTR_WORST_DAY]["date"] == "2026-05-17"
-    assert len(attrs[ATTR_DAILY_BREAKDOWN]) == 3
+    assert ATTR_DAILY_BREAKDOWN not in attrs
 
 
 def test_summary_no_historical_stats_when_store_absent():
-    """CommuteSummarySensor attrs omit historical stats when stats_store is None."""
+    """CommuteSummarySensor attrs omit all historical stats when stats_store is None."""
     sensor = _make_sensor(stats_store=None)
 
     attrs = sensor.extra_state_attributes
@@ -166,7 +167,7 @@ def test_summary_no_historical_stats_when_store_absent():
     assert ATTR_AVG_DELAY_7D not in attrs
     assert ATTR_BEST_DAY not in attrs
     assert ATTR_WORST_DAY not in attrs
-    assert ATTR_DAILY_BREAKDOWN not in attrs
+    assert ATTR_DAILY_BREAKDOWN not in attrs  # never present on summary sensor
 
 
 def test_summary_different_routes_expose_different_stats():


### PR DESCRIPTION
…ithin HA 16 KB attribute limit

Combined with all_trains, including the 30-entry daily_breakdown pushed the entity's state attributes over Home Assistant's 16 KB limit, causing a configuration error when loading the card. daily_breakdown remains available on HistoricalReliabilitySensor; only the summary stats needed for the toggle display (today/7d/30d on-time %, avg delay, best/worst day) are included here.