### PR TITLE
fix(sensor): drop daily_breakdown from CommuteSummarySensor to stay within HA 16 KB attribute limit

### DIFF
--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -41,7 +41,6 @@ from .const import (
     ATTR_PLATFORM,
     ATTR_REVERSE_AVG_DELAY_7D,
     ATTR_REVERSE_BEST_DAY,
-    ATTR_REVERSE_DAILY_BREAKDOWN,
     ATTR_REVERSE_ON_TIME_PCT_7D,
     ATTR_REVERSE_ON_TIME_PCT_30D,
     ATTR_REVERSE_ON_TIME_PCT_TODAY,
@@ -252,7 +251,8 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
             attrs[ATTR_AVG_DELAY_7D] = rolling_7["avg_delay_minutes"]
             attrs[ATTR_WORST_DAY] = best_worst["worst_day"]
             attrs[ATTR_BEST_DAY] = best_worst["best_day"]
-            attrs[ATTR_DAILY_BREAKDOWN] = store.get_daily_breakdown(30)
+            # daily_breakdown omitted here (available on HistoricalReliabilitySensor)
+            # to keep attribute payload within HA's 16 KB limit
 
         # Expose the paired reverse route's stats so that a card configured with
         # only this entity still has access to both directions' stats when toggled.
@@ -284,7 +284,6 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
                 attrs[ATTR_REVERSE_AVG_DELAY_7D] = rev_7["avg_delay_minutes"]
                 attrs[ATTR_REVERSE_WORST_DAY] = rev_bw["worst_day"]
                 attrs[ATTR_REVERSE_BEST_DAY] = rev_bw["best_day"]
-                attrs[ATTR_REVERSE_DAILY_BREAKDOWN] = rev_store.get_daily_breakdown(30)
 
         if data.get("multi_destination"):
             attrs["multi_destination"] = True

--- a/tests/test_sensor_summary_stats.py
+++ b/tests/test_sensor_summary_stats.py
@@ -161,7 +161,7 @@ def test_summary_includes_historical_stats_when_store_present():
     assert ATTR_AVG_DELAY_7D in attrs
     assert ATTR_BEST_DAY in attrs
     assert ATTR_WORST_DAY in attrs
-    assert ATTR_DAILY_BREAKDOWN in attrs
+    assert ATTR_DAILY_BREAKDOWN not in attrs
 
 
 def test_summary_historical_stats_values_match_store():
@@ -182,7 +182,7 @@ def test_summary_historical_stats_values_match_store():
     assert attrs[ATTR_AVG_DELAY_7D] == 3.4
     assert attrs[ATTR_BEST_DAY]["date"] == "2026-05-18"
     assert attrs[ATTR_WORST_DAY]["date"] == "2026-05-17"
-    assert len(attrs[ATTR_DAILY_BREAKDOWN]) == 3
+    assert ATTR_DAILY_BREAKDOWN not in attrs
 
 
 def test_summary_no_historical_stats_when_store_absent():
@@ -250,7 +250,7 @@ def test_reverse_stats_exposed_when_paired_coordinator_exists():
     assert ATTR_REVERSE_AVG_DELAY_7D in attrs
     assert ATTR_REVERSE_BEST_DAY in attrs
     assert ATTR_REVERSE_WORST_DAY in attrs
-    assert ATTR_REVERSE_DAILY_BREAKDOWN in attrs
+    assert ATTR_REVERSE_DAILY_BREAKDOWN not in attrs
 
 
 def test_reverse_stats_values_match_paired_coordinators_store():
@@ -284,7 +284,6 @@ def test_reverse_stats_values_match_paired_coordinators_store():
     assert attrs[ATTR_REVERSE_AVG_DELAY_7D] == 6.2
     assert attrs[ATTR_REVERSE_BEST_DAY]["date"] == "2026-05-18"
     assert attrs[ATTR_REVERSE_WORST_DAY]["date"] == "2026-05-17"
-    assert len(attrs[ATTR_REVERSE_DAILY_BREAKDOWN]) == 3
 
 
 def test_reverse_stats_absent_when_no_paired_coordinator():


### PR DESCRIPTION
Resolves conflict between claude/fix-route-toggle-stats-HBOlV (which dropped
daily_breakdown for size) and main (which had updated _make_sensor returning a
tuple and added reverse-route stats). Resolution keeps the tuple-return helper
and reverse stats from main while applying the daily_breakdown removal from the
PR branch. daily_breakdown remains available on HistoricalReliabilitySensor.

https://claude.ai/code/session_01WGmRe5BVrpMGN1UxNoc9na