### PR TITLE
Fix duplicate device groups when no destination is configured

### DIFF
--- a/custom_components/my_rail_commute/binary_sensor.py
+++ b/custom_components/my_rail_commute/binary_sensor.py
@@ -81,8 +81,11 @@ class NationalRailCommuteBinarySensor(
         origin = coordinator.origin
         destination = coordinator.destination
 
+        device_id = (
+            f"{origin}_{destination}" if destination else f"{origin}_all_departures"
+        )
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{origin}_{destination}")},
+            identifiers={(DOMAIN, device_id)},
             name=commute_name,
             manufacturer="National Rail",
             model="Live Departure Board",


### PR DESCRIPTION
binary_sensor.py was always using `{origin}_{destination}` as the device
identifier, which resolves to `{origin}_None` when no destination is set.
sensor.py already used `{origin}_all_departures` in that case, so the two
platforms registered under different device IDs — causing HA to show them
as separate devices (one with train sensors, one with Has Disruption).

Align binary_sensor.py to use the same fallback so all entities share a
single device when in all-departures mode.

https://claude.ai/code/session_014fUoEhcqssHQWV7ynMAWXE