### PR TITLE
Extend to cover arrival boards too

### DIFF
--- a/custom_components/my_rail_commute/api.py
+++ b/custom_components/my_rail_commute/api.py
@@ -344,14 +344,17 @@ class NationalRailAPI:
         destination_crs: str | None = None,
         time_window: int = 60,
         num_rows: int = 10,
+        arrivals_mode: bool = False,
     ) -> dict[str, Any]:
-        """Get departure board for a route.
+        """Get departure (or arrivals) board for a route.
 
         Args:
             origin_crs: Origin station CRS code (3 letters)
             destination_crs: Destination station CRS code (3 letters), or None for all departures
             time_window: Time window in minutes
             num_rows: Number of services to retrieve
+            arrivals_mode: Fetch arrivals at ``origin_crs`` coming from ``destination_crs``
+                (filterType=from) rather than departures going to it (filterType=to)
 
         Returns:
             Departure board data with services
@@ -361,39 +364,49 @@ class NationalRailAPI:
             NationalRailAPIError: For other API errors
         """
         _LOGGER.debug(
-            "Fetching departure board: %s -> %s (window: %s mins, rows: %s)",
+            "Fetching %s board: %s %s %s (window: %s mins, rows: %s)",
+            "arrivals" if arrivals_mode else "departure",
             origin_crs,
+            "<-" if arrivals_mode else "->",
             destination_crs or "ALL",
             time_window,
             num_rows,
         )
 
         # Use path parameters for the CRS code and query parameters for filters
-        endpoint = f"GetDepBoardWithDetails/{origin_crs.upper()}"
+        endpoint = f"GetArrDepBoardWithDetails/{origin_crs.upper()}"
         params: dict[str, Any] = {
             "timeWindow": time_window,
             "numRows": num_rows,
         }
         if destination_crs:
             params["filterCrs"] = destination_crs.upper()
+            params["filterType"] = "from" if arrivals_mode else "to"
 
         try:
             data = await self._request(endpoint, params)
-            return self._parse_departure_board(data, destination_crs)
+            return self._parse_departure_board(data, destination_crs, arrivals_mode=arrivals_mode)
         except InvalidStationError:
             raise
         except NationalRailAPIError as err:
             _LOGGER.error("Failed to get departure board: %s", err)
             raise
 
-    def _parse_departure_board(self, data: dict[str, Any], destination_crs: str | None = None) -> dict[str, Any]:
-        """Parse departure board response.
+    def _parse_departure_board(
+        self,
+        data: dict[str, Any],
+        destination_crs: str | None = None,
+        arrivals_mode: bool = False,
+    ) -> dict[str, Any]:
+        """Parse departure (or arrivals) board response.
 
         Args:
             data: Raw API response
+            destination_crs: Partner CRS — destination for departures, origin for arrivals
+            arrivals_mode: Parse as an arrivals board (sta/eta + previousCallingPoints)
 
         Returns:
-            Parsed departure board data
+            Parsed board data
         """
         # Handle different response structures
         board = data.get("GetStationBoardResult", data)
@@ -410,31 +423,51 @@ class NationalRailAPI:
 
         parsed_services = []
         for service in services_list:
-            parsed_service = self._parse_service(service, destination_crs)
+            parsed_service = self._parse_service(service, destination_crs, arrivals_mode=arrivals_mode)
             if parsed_service:
                 parsed_services.append(parsed_service)
 
         return {
             "location_name": location_name,
+            # In arrivals mode this is actually the origin partner station name;
+            # the field is reused to keep the parsed shape identical across modes.
             "destination_name": destination_name,
             "services": parsed_services,
             "generated_at": board.get("generatedAt"),
             "nrcc_messages": board.get("nrccMessages", []),
         }
 
-    def _parse_service(self, service: dict[str, Any], destination_crs: str | None = None) -> dict[str, Any] | None:
+    def _parse_service(
+        self,
+        service: dict[str, Any],
+        destination_crs: str | None = None,
+        *,
+        arrivals_mode: bool = False,
+    ) -> dict[str, Any] | None:
         """Parse a single train service.
 
         Args:
             service: Raw service data
+            destination_crs: Partner CRS — destination for departures, origin for arrivals
+            arrivals_mode: Headline times are sta/eta and the partner stop sits in
+                ``previousCallingPoints`` rather than ``subsequentCallingPoints``
 
         Returns:
             Parsed service data or None if invalid
         """
         try:
-            # Basic service info
-            std = service.get("std", "")  # Scheduled departure
-            etd = service.get("etd", "")  # Estimated departure
+            # Basic service info — sta/eta in arrivals mode, std/etd otherwise.
+            # Local names stay std/etd so the delay calc below is unchanged.
+            if arrivals_mode:
+                std = service.get("sta", "")
+                etd = service.get("eta", "")
+            else:
+                std = service.get("std", "")
+                etd = service.get("etd", "")
+            # GetArrDepBoardWithDetails returns combined rows; drop ones without
+            # a headline time for the current mode (e.g. arrival-only terminus rows).
+            if not std:
+                return None
             platform = service.get("platform", "")
             operator_name = service.get("operator", service.get("operatorName", ""))
             service_id = service.get("serviceID", service.get("serviceIdUrlSafe", ""))
@@ -449,9 +482,11 @@ class NationalRailAPI:
 
             if not is_cancelled and etd and etd != "On time":
                 status = STATUS_DELAYED
-                expected_departure = etd
-                # Try to parse delay from etd if it's a time
-                if _TIME_FORMAT_RE.match(etd) and _TIME_FORMAT_RE.match(std):
+                # ``etd`` may be a status word ("Delayed", "Cancelled"); only keep it
+                # as a real estimate when it looks like a clock time.
+                if _TIME_FORMAT_RE.match(etd):
+                    expected_departure = etd
+                if expected_departure and _TIME_FORMAT_RE.match(std):
                     try:
                         # Use a reference date to parse times and handle midnight crossing
                         std_time = datetime.strptime(f"2000-01-01 {std}", "%Y-%m-%d %H:%M")
@@ -483,34 +518,71 @@ class NationalRailAPI:
             elif isinstance(destination, dict):
                 destination = destination.get("locationName", "")
 
-            # Subsequent calling points and arrival time
+            # Origin name (shown in arrivals mode)
+            origin = service.get("origin", [])
+            if isinstance(origin, list) and origin:
+                origin = origin[0].get("locationName", "")
+            elif isinstance(origin, dict):
+                origin = origin.get("locationName", "")
+            else:
+                origin = ""
+
+            # Walk subsequent (departures) or previous (arrivals) calling points
+            # to find destination_crs and capture its st/et times.
             calling_points = []
             scheduled_arrival = None
             estimated_arrival = None
-            subsequent_points = service.get("subsequentCallingPoints", [])
+            points_key = "previousCallingPoints" if arrivals_mode else "subsequentCallingPoints"
+            subsequent_points = service.get(points_key, [])
             if isinstance(subsequent_points, list) and subsequent_points:
                 calling_point_list = subsequent_points[0].get("callingPoint", [])
                 if not isinstance(calling_point_list, list):
                     calling_point_list = [calling_point_list]
 
-                # Build calling points list, truncating at destination if configured
+                # Build calling points list, truncating at the partner stop. In
+                # arrivals mode the partner is the start of the leg (keep stops
+                # from there onward); in departures mode it's the end.
                 dest_point = None
                 filtered = []
                 for cp in calling_point_list:
                     if not cp:
                         continue
-                    filtered.append(cp)
-                    if destination_crs and cp.get("crs", "").upper() == destination_crs.upper():
-                        dest_point = cp
-                        break  # Stop collecting stops after the destination
+                    is_partner = destination_crs and cp.get("crs", "").upper() == destination_crs.upper()
+                    if arrivals_mode:
+                        if is_partner and dest_point is None:
+                            dest_point = cp
+                            filtered = [cp]
+                        elif dest_point is not None:
+                            filtered.append(cp)
+                    else:
+                        filtered.append(cp)
+                        if is_partner:
+                            dest_point = cp
+                            break  # Stop collecting stops after the destination
 
-                if dest_point is None and filtered:
-                    dest_point = filtered[-1]
+                if dest_point is None and calling_point_list:
+                    # Fall back to first/last known stop if we couldn't match the CRS.
+                    valid = [cp for cp in calling_point_list if cp]
+                    if arrivals_mode:
+                        dest_point = valid[0] if valid else None
+                        filtered = valid
+                    else:
+                        dest_point = valid[-1] if valid else None
 
                 calling_points = [cp.get("locationName", "") for cp in filtered]
                 if dest_point:
                     scheduled_arrival = dest_point.get("st")
-                    estimated_arrival = dest_point.get("et")
+                    raw_et = dest_point.get("et")
+                    # ``et`` may be a status word ("On time", "Delayed", "Cancelled");
+                    # only keep it as an estimate when it's an actual clock time.
+                    if raw_et and _TIME_FORMAT_RE.match(raw_et):
+                        estimated_arrival = raw_et
+
+            # In arrivals mode our headline std/etd are arrival-here times and
+            # the partner-stop times are the departure side — swap the pairs.
+            if arrivals_mode:
+                std, scheduled_arrival = scheduled_arrival, std
+                expected_departure, estimated_arrival = estimated_arrival, expected_departure
 
             return {
                 "scheduled_departure": std,
@@ -527,6 +599,7 @@ class NationalRailAPI:
                 "scheduled_arrival": scheduled_arrival,
                 "estimated_arrival": estimated_arrival or scheduled_arrival,
                 "destination": destination,
+                "origin": origin,
             }
         except Exception as err:
             _LOGGER.error("Error parsing service: %s", err)

--- a/custom_components/my_rail_commute/binary_sensor.py
+++ b/custom_components/my_rail_commute/binary_sensor.py
@@ -78,14 +78,8 @@ class NationalRailCommuteBinarySensor(
 
         # Create device info
         commute_name = entry.data.get(CONF_COMMUTE_NAME, "My Rail Commute")
-        origin = coordinator.origin
-        destination = coordinator.destination
-
-        device_id = (
-            f"{origin}_{destination}" if destination else f"{origin}_all_departures"
-        )
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_id)},
+            identifiers={(DOMAIN, coordinator.device_id)},
             name=commute_name,
             manufacturer="National Rail",
             model="Live Departure Board",

--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -23,8 +23,12 @@ from .api import (
     NationalRailAPIError,
 )
 from .const import (
+    BOARD_TYPE_ARRIVALS,
+    BOARD_TYPE_DEPARTURES,
+    CONF_ADD_ARRIVALS,
     CONF_ADD_RETURN_JOURNEY,
     CONF_ALL_DEPARTURES,
+    CONF_BOARD_TYPE,
     CONF_COMMUTE_NAME,
     CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
@@ -544,10 +548,23 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
+    def _shared_entry_settings(self) -> dict[str, Any]:
+        """The common settings shared by every auto-created entry."""
+        return {
+            CONF_API_KEY: self._api_key,
+            CONF_TIME_WINDOW: self._time_window,
+            CONF_NUM_SERVICES: self._num_services,
+            CONF_NIGHT_UPDATES: self._night_updates,
+            CONF_SEVERE_DELAY_THRESHOLD: self._severe_delay_threshold,
+            CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
+            CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
+            CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
+        }
+
     async def async_step_return_journey(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Offer to set up the reverse commute if it doesn't already exist.
+        """Offer to set up companion boards (return journey and/or arrivals) if they don't already exist.
 
         Args:
             user_input: User input data
@@ -555,45 +572,62 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Returns:
             FlowResult for creating entry
         """
+        existing = list(self._async_current_entries())
         reverse_unique_id = f"{self._destination}_{self._origin}"
-        reverse_exists = any(
-            entry.unique_id == reverse_unique_id
-            for entry in self._async_current_entries()
-        )
+        reverse_exists = any(e.unique_id == reverse_unique_id for e in existing)
+        arrivals_unique_id = f"{self._origin}_{self._destination}_arr"
+        arrivals_exists = any(e.unique_id == arrivals_unique_id for e in existing)
 
-        if reverse_exists:
+        # Nothing left to offer — just create the primary entry.
+        if reverse_exists and arrivals_exists:
             return self._create_entry()
 
         if user_input is not None:
-            if user_input.get(CONF_ADD_RETURN_JOURNEY, False):
+            if not reverse_exists and user_input.get(CONF_ADD_RETURN_JOURNEY, False):
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_init(
                         DOMAIN,
                         context={"source": config_entries.SOURCE_IMPORT},
                         data={
-                            CONF_API_KEY: self._api_key,
+                            **self._shared_entry_settings(),
                             CONF_ORIGIN: self._destination,
                             CONF_DESTINATION: self._origin,
                             CONF_COMMUTE_NAME: f"{self._destination_name} to {self._origin_name}",
-                            CONF_TIME_WINDOW: self._time_window,
-                            CONF_NUM_SERVICES: self._num_services,
-                            CONF_NIGHT_UPDATES: self._night_updates,
-                            CONF_SEVERE_DELAY_THRESHOLD: self._severe_delay_threshold,
-                            CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
-                            CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
-                            CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
+                        },
+                    )
+                )
+            if not arrivals_exists and user_input.get(CONF_ADD_ARRIVALS, False):
+                self.hass.async_create_task(
+                    self.hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": config_entries.SOURCE_IMPORT},
+                        data={
+                            **self._shared_entry_settings(),
+                            CONF_ORIGIN: self._origin,
+                            CONF_DESTINATION: self._destination,
+                            CONF_BOARD_TYPE: BOARD_TYPE_ARRIVALS,
+                            CONF_COMMUTE_NAME: (
+                                f"Arrivals at {self._origin_name} "
+                                f"from {self._destination_name}"
+                            ),
                         },
                     )
                 )
             return self._create_entry()
 
+        schema: dict[Any, Any] = {}
+        if not reverse_exists:
+            schema[vol.Required(CONF_ADD_RETURN_JOURNEY, default=True)] = (
+                selector.BooleanSelector()
+            )
+        if not arrivals_exists:
+            schema[vol.Required(CONF_ADD_ARRIVALS, default=False)] = (
+                selector.BooleanSelector()
+            )
+
         return self.async_show_form(
             step_id="return_journey",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_ADD_RETURN_JOURNEY, default=True): selector.BooleanSelector(),
-                }
-            ),
+            data_schema=vol.Schema(schema),
             description_placeholders={
                 "origin": self._origin_name,
                 "destination": self._destination_name,
@@ -603,19 +637,23 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(
         self, user_input: dict[str, Any]
     ) -> FlowResult:
-        """Handle automatic creation of a return journey config entry.
+        """Handle automatic creation of a companion config entry (return journey or arrivals board).
 
-        Called programmatically (no UI) when the user accepts the return
-        journey offer. Creates the reverse route using the same settings.
+        Called programmatically (no UI) when the user accepts an offer in the
+        companion-boards step. Aborts if the entry already exists.
 
         Args:
-            user_input: Pre-populated entry data for the reverse route
+            user_input: Pre-populated entry data
 
         Returns:
             FlowResult creating the entry, or aborting if already configured
         """
+        # Arrivals entries share the same CRS pair as the departures entry, so
+        # keep their unique_id distinct with an _arr suffix.
+        board_type = user_input.get(CONF_BOARD_TYPE, BOARD_TYPE_DEPARTURES)
+        suffix = "_arr" if board_type == BOARD_TYPE_ARRIVALS else ""
         await self.async_set_unique_id(
-            f"{user_input[CONF_ORIGIN]}_{user_input[CONF_DESTINATION]}"
+            f"{user_input[CONF_ORIGIN]}_{user_input[CONF_DESTINATION]}{suffix}"
         )
         self._abort_if_unique_id_configured()
         return self.async_create_entry(
@@ -626,17 +664,11 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _create_entry(self) -> FlowResult:
         """Create the config entry using stored instance variables."""
         data: dict[str, Any] = {
-            CONF_API_KEY: self._api_key,
+            **self._shared_entry_settings(),
             CONF_ORIGIN: self._origin,
             CONF_ALL_DEPARTURES: self._all_departures,
+            CONF_BOARD_TYPE: BOARD_TYPE_DEPARTURES,
             CONF_COMMUTE_NAME: self._commute_name,
-            CONF_TIME_WINDOW: self._time_window,
-            CONF_NUM_SERVICES: self._num_services,
-            CONF_NIGHT_UPDATES: self._night_updates,
-            CONF_SEVERE_DELAY_THRESHOLD: self._severe_delay_threshold,
-            CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
-            CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
-            CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
         }
         if self._destination:
             data[CONF_DESTINATION] = self._destination

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -19,6 +19,13 @@ CONF_MINOR_DELAY_THRESHOLD: Final = "minor_delay_threshold"
 CONF_DEPARTED_TRAIN_GRACE_PERIOD: Final = "departed_train_grace_period"
 CONF_ADD_RETURN_JOURNEY: Final = "add_return_journey"
 CONF_ALL_DEPARTURES: Final = "all_departures"
+CONF_ADD_ARRIVALS: Final = "add_arrivals"
+# Which board a config entry tracks at its origin station: departures from it,
+# or arrivals into it (filtered to trains coming from the destination).
+CONF_BOARD_TYPE: Final = "board_type"
+BOARD_TYPE_DEPARTURES: Final = "departures"
+BOARD_TYPE_ARRIVALS: Final = "arrivals"
+DEFAULT_BOARD_TYPE: Final = BOARD_TYPE_DEPARTURES
 
 # Legacy config keys (for migration)
 CONF_DISRUPTION_SINGLE_DELAY: Final = "disruption_single_delay"
@@ -27,7 +34,7 @@ CONF_DISRUPTION_MULTIPLE_COUNT: Final = "disruption_multiple_count"
 
 # API Configuration
 API_BASE_URL: Final = (
-    "https://api1.raildata.org.uk/1010-live-departure-board-dep1_2/LDBWS/api/20220120"
+    "https://api1.raildata.org.uk/1010-live-arrival-and-departure-boards-arr-and-dep1_1/LDBWS/api/20220120"
 )
 API_TIMEOUT: Final = 30
 

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -13,7 +13,9 @@ from homeassistant.util import dt as dt_util
 
 from .api import NationalRailAPI, NationalRailAPIError
 from .const import (
+    BOARD_TYPE_ARRIVALS,
     CONF_ALL_DEPARTURES,
+    CONF_BOARD_TYPE,
     CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
     CONF_DISRUPTION_MULTIPLE_COUNT,
@@ -78,6 +80,13 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         self.origin = config[CONF_ORIGIN]
         self.destination = config.get(CONF_DESTINATION)  # None when all_departures=True
         self.all_departures = config.get(CONF_ALL_DEPARTURES, False)
+        # Arrivals mode: trains arriving at origin from destination. Requires a destination
+        # (never applies to all-departures entries).
+        self.is_arrivals = (
+            config.get(CONF_BOARD_TYPE) == BOARD_TYPE_ARRIVALS
+            and self.destination is not None
+            and not self.all_departures
+        )
         self.time_window = int(config[CONF_TIME_WINDOW])
         self.num_services = int(config[CONF_NUM_SERVICES])
         self.night_updates_enabled = config.get(CONF_NIGHT_UPDATES, False)
@@ -140,6 +149,16 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             name=DOMAIN,
             update_interval=update_interval,
         )
+
+    @property
+    def device_id(self) -> str:
+        """Stable HA device registry identifier for this coordinator's entities."""
+        base = (
+            f"{self.origin}_{self.destination}"
+            if self.destination
+            else f"{self.origin}_all_departures"
+        )
+        return f"{base}_arr" if self.is_arrivals else base
 
     def _get_update_interval(self) -> timedelta:
         """Get update interval based on current time.
@@ -207,6 +226,7 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 destination_crs=self.destination,
                 time_window=self.time_window,
                 num_rows=num_rows,
+                arrivals_mode=self.is_arrivals,
             )
 
             # Store station names
@@ -287,17 +307,22 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         current_time_str = now.strftime("%H:%M")
         filtered_services = []
 
+        # In arrivals mode the relevant moment is the train's arrival here, not
+        # its departure from elsewhere — filter out ones that have already
+        # arrived rather than already departed.
+        if self.is_arrivals:
+            primary_key, fallback_key = "estimated_arrival", "scheduled_arrival"
+        else:
+            primary_key, fallback_key = "expected_departure", "scheduled_departure"
+
         for service in services:
             # Skip cancelled trains - they should be shown regardless of time
             if service.get("is_cancelled", False):
                 filtered_services.append(service)
                 continue
 
-            # Get departure time (prefer expected, fallback to scheduled)
-            if "expected_departure" in service:
-                departure_time = service["expected_departure"]
-            else:
-                departure_time = service.get("scheduled_departure")
+            # Get the relevant time (prefer the live estimate, fallback to scheduled)
+            departure_time = service.get(primary_key) or service.get(fallback_key)
 
             if not departure_time or not _TIME_FORMAT_RE.match(departure_time):
                 # If we can't parse the time, keep the service

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -129,22 +129,25 @@ class NationalRailCommuteEntity(CoordinatorEntity[NationalRailDataUpdateCoordina
 
         self._entry = entry
         self._attr_has_entity_name = True
+        self._is_arrivals = coordinator.is_arrivals
 
         # Create device info
         commute_name = entry.data.get(CONF_COMMUTE_NAME, "My Rail Commute")
-        origin = coordinator.origin
-        destination = coordinator.destination
-
-        device_id = (
-            f"{origin}_{destination}" if destination else f"{origin}_all_departures"
-        )
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_id)},
+            identifiers={(DOMAIN, coordinator.device_id)},
             name=commute_name,
             manufacturer="National Rail",
             model="Live Departure Board",
             entry_type="service",
         )
+
+    @property
+    def _mode(self) -> str:
+        return "arrivals" if self._is_arrivals else "departures"
+
+    @staticmethod
+    def _arrival_time(train: dict[str, Any]) -> str | None:
+        return train.get("estimated_arrival") or train.get("scheduled_arrival")
 
 
 class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
@@ -266,6 +269,7 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
                     if (
                         isinstance(c, NationalRailDataUpdateCoordinator)
                         and c is not self.coordinator
+                        and not c.is_arrivals
                         and c.origin == self.coordinator.destination
                         and c.destination == self.coordinator.origin
                     )
@@ -443,7 +447,9 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
         super().__init__(coordinator, entry)
 
         self._train_number = train_number
-        self._attr_name = f"Train {train_number}"
+        self._attr_name = (
+            f"Arrival {train_number}" if self._is_arrivals else f"Train {train_number}"
+        )
         self._attr_unique_id = f"{entry.entry_id}_train_{train_number}"
 
         # Platform change tracking
@@ -612,6 +618,8 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
             "train_number": self._train_number,
             "total_trains": len(services),
             "departure_time": departure_time,  # Moved from state to attribute
+            "arrival_time": self._arrival_time(train),
+            "mode": self._mode,
             ATTR_SCHEDULED_DEPARTURE: train.get("scheduled_departure"),
             ATTR_EXPECTED_DEPARTURE: train.get("expected_departure"),
             ATTR_PLATFORM: train.get("platform"),
@@ -685,7 +693,7 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
         """
         super().__init__(coordinator, entry)
 
-        self._attr_name = "Next Train"
+        self._attr_name = "Next Arrival" if self._is_arrivals else "Next Train"
         self._attr_unique_id = f"{entry.entry_id}_next_train"
         self._attr_icon = "mdi:train-car"
 
@@ -839,6 +847,8 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
             "train_number": 1,
             "total_trains": len(services),
             "departure_time": departure_time,  # Moved from state to attribute
+            "arrival_time": self._arrival_time(train),
+            "mode": self._mode,
             ATTR_SCHEDULED_DEPARTURE: train.get("scheduled_departure"),
             ATTR_EXPECTED_DEPARTURE: train.get("expected_departure"),
             ATTR_PLATFORM: train.get("platform"),

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -32,10 +32,11 @@
         }
       },
       "return_journey": {
-        "title": "Return Journey",
-        "description": "Would you also like to set up the return journey from {destination} to {origin}? It will use the same settings as this commute.",
+        "title": "Companion boards",
+        "description": "Would you also like to add companion boards for {origin} ↔ {destination}? The return journey tracks departures from {destination} back to {origin}; the arrivals board tracks trains arriving at {origin} from {destination}. Each is a separate device using the same settings as this commute.",
         "data": {
-          "add_return_journey": "Set up return journey"
+          "add_return_journey": "Set up return journey (opposite departures)",
+          "add_arrivals": "Track arrivals at this station"
         }
       }
     },

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -32,10 +32,11 @@
         }
       },
       "return_journey": {
-        "title": "Return Journey",
-        "description": "Would you also like to set up the return journey from {destination} to {origin}? It will use the same settings as this commute.",
+        "title": "Companion boards",
+        "description": "Would you also like to add companion boards for {origin} ↔ {destination}? The return journey tracks departures from {destination} back to {origin}; the arrivals board tracks trains arriving at {origin} from {destination}. Each is a separate device using the same settings as this commute.",
         "data": {
-          "add_return_journey": "Set up return journey"
+          "add_return_journey": "Set up return journey (opposite departures)",
+          "add_arrivals": "Track arrivals at this station"
         }
       }
     },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,7 +175,7 @@ class TestGetDepartureBoard:
         """Test successful departure board retrieval."""
         with aioresponses() as mock:
             mock.get(
-                f"{API_BASE_URL}/GetDepBoardWithDetails/PAD?filterCrs=RDG&timeWindow=60&numRows=10",
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/PAD?timeWindow=60&numRows=10&filterCrs=RDG&filterType=to",
                 payload=departure_board_response,
                 status=200,
             )
@@ -191,7 +191,7 @@ class TestGetDepartureBoard:
         """Test that station codes are converted to uppercase."""
         with aioresponses() as mock:
             mock.get(
-                f"{API_BASE_URL}/GetDepBoardWithDetails/PAD?filterCrs=RDG&timeWindow=60&numRows=10",
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/PAD?timeWindow=60&numRows=10&filterCrs=RDG&filterType=to",
                 payload={"GetStationBoardResult": {"locationName": "Test", "trainServices": []}},
                 status=200,
             )
@@ -203,7 +203,7 @@ class TestGetDepartureBoard:
         """Test departure board with custom parameters."""
         with aioresponses() as mock:
             mock.get(
-                f"{API_BASE_URL}/GetDepBoardWithDetails/PAD?filterCrs=RDG&timeWindow=120&numRows=5",
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/PAD?timeWindow=120&numRows=5&filterCrs=RDG&filterType=to",
                 payload={"GetStationBoardResult": {"locationName": "Test", "trainServices": []}},
                 status=200,
             )
@@ -211,11 +211,23 @@ class TestGetDepartureBoard:
             await api_client.get_departure_board("PAD", "RDG", time_window=120, num_rows=5)
             # If no exception, test passes
 
+    async def test_get_departure_board_all_services(self, api_client):
+        """All-departures mode (no destination): no filterCrs or filterType params."""
+        with aioresponses() as mock:
+            mock.get(
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/PAD?timeWindow=60&numRows=10",
+                payload={"GetStationBoardResult": {"locationName": "Test", "trainServices": []}},
+                status=200,
+            )
+
+            await api_client.get_departure_board("PAD")
+            # If no exception, test passes
+
     async def test_get_departure_board_invalid_station(self, api_client):
         """Test departure board with invalid station."""
         with aioresponses() as mock:
             mock.get(
-                f"{API_BASE_URL}/GetDepBoardWithDetails/XYZ?filterCrs=RDG&timeWindow=60&numRows=10",
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/XYZ?timeWindow=60&numRows=10&filterCrs=RDG&filterType=to",
                 status=404,
             )
 
@@ -226,7 +238,7 @@ class TestGetDepartureBoard:
         """Test departure board with 400 bad request (invalid CRS code)."""
         with aioresponses() as mock:
             mock.get(
-                f"{API_BASE_URL}/GetDepBoardWithDetails/PAS?filterCrs=RDG&timeWindow=60&numRows=10",
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/PAS?timeWindow=60&numRows=10&filterCrs=RDG&filterType=to",
                 status=400,
             )
 
@@ -237,7 +249,7 @@ class TestGetDepartureBoard:
         """Test departure board raises NationalRailAPIError when API returns invalid JSON."""
         with aioresponses() as mock:
             mock.get(
-                f"{API_BASE_URL}/GetDepBoardWithDetails/PAD?filterCrs=WAT&timeWindow=60&numRows=10",
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/PAD?timeWindow=60&numRows=10&filterCrs=WAT&filterType=to",
                 status=200,
                 body="<html>Bad Gateway</html>",
                 content_type="text/html",
@@ -245,6 +257,112 @@ class TestGetDepartureBoard:
 
             with pytest.raises(NationalRailAPIError):
                 await api_client.get_departure_board("PAD", "WAT")
+
+
+class TestGetArrivalBoard:
+    """Tests for the arrivals board (trains arriving from a partner station)."""
+
+    async def test_get_arrival_board_success(self, api_client):
+        """Arrivals board uses filterType=from and parses arrival times."""
+        payload = {
+            "GetStationBoardResult": {
+                "locationName": "Hometown",
+                "filterLocationName": "Worktown",
+                "generatedAt": "2024-01-15T18:00:00",
+                "trainServices": {
+                    "service": [
+                        {
+                            "sta": "18:20",
+                            "eta": "On time",
+                            "platform": "2",
+                            "operator": "Great Western Railway",
+                            "serviceID": "arr1",
+                            "origin": [{"locationName": "Worktown", "crs": "WRK"}],
+                            "destination": [{"locationName": "Endville", "crs": "END"}],
+                            "previousCallingPoints": [
+                                {
+                                    "callingPoint": [
+                                        {
+                                            "locationName": "Worktown",
+                                            "crs": "WRK",
+                                            "st": "17:50",
+                                            "et": "On time",
+                                        }
+                                    ]
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        }
+        with aioresponses() as mock:
+            mock.get(
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/HOM?filterCrs=WRK&filterType=from&timeWindow=60&numRows=10",
+                payload=payload,
+                status=200,
+            )
+
+            result = await api_client.get_departure_board("HOM", "WRK", arrivals_mode=True)
+
+            assert result["location_name"] == "Hometown"
+            assert result["destination_name"] == "Worktown"
+            assert len(result["services"]) == 1
+            svc = result["services"][0]
+            assert svc["scheduled_arrival"] == "18:20"
+            # "On time" normalises to the scheduled clock time.
+            assert svc["estimated_arrival"] == "18:20"
+            assert svc["status"] == "on_time"
+            # Departed-partner time comes from previousCallingPoints.
+            assert svc["scheduled_departure"] == "17:50"
+
+    async def test_get_arrival_board_uppercase(self, api_client):
+        """Station codes are upper-cased in the arrivals request."""
+        with aioresponses() as mock:
+            mock.get(
+                f"{API_BASE_URL}/GetArrDepBoardWithDetails/HOM?filterCrs=WRK&filterType=from&timeWindow=60&numRows=10",
+                payload={"GetStationBoardResult": {"locationName": "Test", "trainServices": []}},
+                status=200,
+            )
+
+            await api_client.get_departure_board("hom", "wrk", arrivals_mode=True)
+            # If no exception, test passes
+
+
+class TestParseArrivalService:
+    """Tests for arrival service parsing."""
+
+    async def test_parse_arrival_delayed(self, api_client):
+        """A delayed arrival reports estimated arrival, delay, and left-partner time."""
+        service_data = {
+            "sta": "18:35",
+            "eta": "18:41",
+            "platform": "1",
+            "operator": "Great Western Railway",
+            "serviceID": "late",
+            "origin": [{"locationName": "Worktown", "crs": "WRK"}],
+            "destination": [{"locationName": "Hometown", "crs": "HOM"}],
+            "previousCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "Worktown", "crs": "WRK", "st": "18:05", "et": "18:09"}
+                    ]
+                }
+            ],
+        }
+        result = api_client._parse_service(service_data, arrivals_mode=True, destination_crs="WRK")
+        assert result is not None
+        assert result["scheduled_arrival"] == "18:35"
+        assert result["estimated_arrival"] == "18:41"
+        assert result["delay_minutes"] == 6
+        assert result["status"] == "delayed"
+        assert result["expected_departure"] == "18:09"
+        assert result["origin"] == "Worktown"
+
+    async def test_parse_arrival_drops_service_without_sta(self, api_client):
+        """A departure-only row (no sta) is not an inbound arrival and is dropped."""
+        result = api_client._parse_service({"std": "18:25", "etd": "On time"}, arrivals_mode=True, destination_crs="WRK")
+        assert result is None
 
 
 class TestParseService:
@@ -366,7 +484,32 @@ class TestParseService:
         result = api_client._parse_service(service_data, destination_crs="LBG")
 
         assert result["scheduled_arrival"] == "08:45"
-        assert result["estimated_arrival"] == "On time"
+        # "On time" is a status word, not a clock time: estimated_arrival
+        # normalizes to the scheduled arrival (mirrors expected_departure).
+        assert result["estimated_arrival"] == "08:45"
+
+    async def test_parse_service_keeps_real_estimated_arrival_when_delayed(self, api_client):
+        """A real ``et`` clock time at the destination is preserved as estimated_arrival."""
+        service_data = {
+            "std": "08:32",
+            "etd": "08:40",
+            "platform": "3",
+            "operator": "Thameslink",
+            "serviceID": "service_delayed",
+            "destination": [{"locationName": "Cannon Street", "crs": "CST"}],
+            "subsequentCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "London Bridge", "crs": "LBG", "st": "08:45", "et": "08:51"},
+                    ]
+                }
+            ],
+        }
+
+        result = api_client._parse_service(service_data, destination_crs="LBG")
+
+        assert result["scheduled_arrival"] == "08:45"
+        assert result["estimated_arrival"] == "08:51"
 
     async def test_parse_service_falls_back_to_last_point_when_no_destination_crs(self, api_client):
         """Test that scheduled_arrival falls back to the last calling point when no destination_crs given."""
@@ -562,8 +705,8 @@ class TestAPIRetryLogic:
             assert result is True
 
 
-class TestParseDepartureBoard:
-    """Tests for departure board parsing."""
+class TestParseBoard:
+    """Tests for board parsing (departures and arrivals)."""
 
     async def test_parse_departure_board_with_services(
         self, api_client, departure_board_response


### PR DESCRIPTION
I wanted to also have data on train arrivals as I occasionally use those to know when to meet someone at the home train station.

This PR does that by adding a CONF_BOARD_TYPE field (departures/arrivals) on each config entry. The companion-boards step in the config flow offers both a return journey and an arrivals-at-home board; the latter is created with board_type=arrivals and a _arr unique-id suffix for the sensors and entries so that they stay independent.

API-wise this means a switch to GetArrDepBoardWithDetails, which is a strict superset of the GetDepBoardWithDetails used before, with extra params for the direction. It supports the same API key, so this change should be backward compatible for existing users (myself included).