### PR TITLE
Add Recent Train Times feature via Network Rail Open Data feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A custom Home Assistant integration that tracks regular commutes using National 
 - **Multi-Route Support**: Configure multiple commutes (e.g., morning and evening journeys)
 - **All Departures Mode**: Optionally track all departures from an origin station with no fixed destination
 - **Historical Performance Tracking**: Persistent daily statistics with rolling 7-day and 30-day on-time percentages and average delays
+- **Recent Train Times**: Optional log of actual departure/arrival times for recently-run trains, sourced from Network Rail's real-time movement feed — see how delayed your train actually was, not just its live-board estimate
 - **UI Configuration**: Easy setup through Home Assistant's config flow interface
 - **HACS Compatible**: Simple installation via Home Assistant Community Store
 - **Custom Lovelace Card**: Beautiful, dedicated [dashboard card](https://github.com/adamf83/lovelace-my-rail-commute-card) for displaying train information
@@ -144,6 +145,20 @@ The integration creates multiple sensors for each configured commute:
   - `days_with_data_7day`: Days with recorded data in the 7-day window
 - **Use Case**: Understand whether your route is getting better or worse, and identify your worst days
 
+### 8. Recent Train Times Sensor (optional)
+- **Entity ID**: `sensor.{commute_name}_recent_train_times`
+- **Requires**: Recent Train Times enabled for this commute (see [Prerequisites](#network-rail-open-data-account-optional))
+- **State**: Status of the most recently-run journey (e.g., "On Time", "7 min late", "Cancelled", or "No recent journeys")
+- **Attributes**:
+  - `recent_journeys`: The last 20 recorded journeys, newest first, each with scheduled/actual departure and arrival times, platform, TOC, delay minutes, and cancellation details
+  - `last_journey`: The most recent journey record
+  - `journeys_recorded_today`: Count of journeys recorded so far today
+  - `feed_connected`: Whether the Network Rail Open Data feed is currently connected
+  - `feed_last_message_at`: Timestamp of the last message received from the feed
+- **Use Case**: Check whether a train you just missed (or are about to catch) has historically been on time — genuinely "recent" data, unlike the live departure board which stops showing a service a couple of minutes after it departs
+
+This sensor is backed by a different data source (Network Rail's real-time movement feed) than the rest of the integration (Darwin live departure boards), so it also adds a diagnostic **Recent Train Times Feed Connected** binary sensor to help confirm the feed is receiving data.
+
 ## Actions
 
 The integration provides several actions (callable via **Developer Tools → Actions** or automations):
@@ -168,6 +183,16 @@ data:
 
 The response includes an array of daily records with `date`, `on_time_count`, `delayed_count`, `cancelled_count`, `total_observations`, and `total_delay_minutes`.
 
+### Get Recent Journeys
+Retrieve the log of recent actual train times (Recent Train Times feature) for a commute, newest first. Requires Recent Train Times to be enabled for that commute.
+
+```yaml
+action: my_rail_commute.get_recent_journeys
+data:
+  entry_id: "your_config_entry_id"
+  limit: 20
+```
+
 ## Prerequisites
 
 ### National Rail API Key
@@ -189,6 +214,19 @@ You'll need the 3-letter CRS (Computer Reservation System) codes for your statio
 - **BHM** = Birmingham New Street
 
 Find your station codes at [National Rail Enquiries](https://www.nationalrail.co.uk/stations/).
+
+### Network Rail Open Data Account (optional)
+
+Only needed if you want to enable the **Recent Train Times** feature. This is a separate, free account from the Rail Data Marketplace key above:
+
+1. Visit [Network Rail Open Data Feeds](https://publicdatafeeds.networkrail.co.uk/)
+2. Register for a free account
+3. Request access to the **TRAIN_MVT_ALL_TOC** real-time train movement feed
+4. Use your account username/password when enabling Recent Train Times in the integration's config flow or options
+
+These credentials are shared across all your commutes automatically, the same way your Rail Data Marketplace API key is — you only need to enter them once.
+
+**Note**: Network Rail's feed only supports a single active connection per account, so this integration always shares one connection across every commute you have Recent Train Times enabled for. Don't run another tool against the same account's TRAIN_MVT_ALL_TOC feed at the same time.
 
 ## Installation
 
@@ -238,6 +276,7 @@ Find your station codes at [National Rail Enquiries](https://www.nationalrail.co
 - **Major Delays Threshold**: Minutes of delay to trigger "Major Delays" status for any train (1-60 minutes, default: 10)
 - **Minor Delays Threshold**: Minutes of delay to trigger "Minor Delays" status for any train (1-60 minutes, default: 3)
 - **Enable Night-Time Updates**: Keep polling during night hours (23:00-05:00)
+- **Enable Recent Train Times**: Optional; requires a fixed destination (not available with "All Departures"). If enabled and no Network Rail Open Data credentials are on file yet, you'll be asked for them in an extra step next
 
 **Note on Status Hierarchy**: The Status sensor uses a 5-level hierarchy based on the maximum delay across all trains:
 - **"Normal"**: All trains on time (or below minor threshold)
@@ -260,6 +299,7 @@ All three delay thresholds are fully customizable. Validation ensures the hierar
    - Major Delays Threshold
    - Minor Delays Threshold
    - Night-time updates
+   - Recent Train Times (and Network Rail Open Data credentials, if not already set on another commute)
 
 **Note**: When you update your configuration, any old threshold settings will automatically migrate to the new format.
 
@@ -548,6 +588,15 @@ The integration includes automatic retry with exponential backoff. If you see ra
 - Increase time windows between updates
 - Disable night-time updates if not needed
 
+### Recent Train Times Feed Issues
+
+- Check the **Recent Train Times Feed Connected** binary sensor — if it's off, the feed isn't currently connected
+- Double-check your Network Rail Open Data username and password are correct (these are separate from your Rail Data Marketplace API key)
+- Confirm your NROD account has been granted access to the **TRAIN_MVT_ALL_TOC** feed
+- Only one connection per NROD account is allowed at a time — if you run another tool or a second Home Assistant instance against the same account, one of them will be disconnected
+- Recent Train Times will show no data until at least one train has actually run on your route since the feed connected; it does not backfill history from before it started
+- If NROD credentials are wrong or the feed is unavailable, this only disables Recent Train Times — your other sensors keep working normally
+
 ## API Information
 
 This integration uses the National Rail Darwin Live Departure Boards API:
@@ -557,6 +606,13 @@ This integration uses the National Rail Darwin Live Departure Boards API:
 - **Format**: REST/JSON
 - **Rate Limits**: Fair usage policy (usually no issues with default settings)
 - **Terms**: [Rail Data Marketplace Terms](https://raildata.org.uk/terms)
+
+The optional Recent Train Times feature additionally uses Network Rail's Open Data real-time train movement feed:
+
+- **Provider**: Network Rail
+- **Feed**: TRAIN_MVT_ALL_TOC, delivered over STOMP
+- **Format**: Push-based JSON messages, not a request/response API
+- **Terms**: [Network Rail Open Data Feeds](https://publicdatafeeds.networkrail.co.uk/) — see the [Open Rail Data wiki](https://wiki.openraildata.com/) for feed documentation
 
 ## Contributing
 
@@ -576,6 +632,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - National Rail and Rail Delivery Group for providing the Darwin API
 - Rail Data Marketplace for API access
+- Network Rail for the Open Data real-time train movement feed
 - Home Assistant community for integration development resources
 
 ## Disclaimer
@@ -584,7 +641,9 @@ This is an unofficial integration and is not affiliated with, endorsed by, or co
 
 Train times and information are provided by National Rail's systems. While we strive for accuracy, always verify critical journey information through official channels.
 
+Recent Train Times data depends on the completeness and timeliness of each train operating company's reporting into Network Rail's movement feed — occasional missing or delayed messages are a known characteristic of the feed itself, not a bug in this integration.
+
 ---
 
-**Version**: 1.1.5
+**Version**: 1.2.0
 **Minimum Home Assistant Version**: 2024.1.0

--- a/custom_components/my_rail_commute/__init__.py
+++ b/custom_components/my_rail_commute/__init__.py
@@ -3,32 +3,102 @@ from __future__ import annotations
 
 import logging
 
-import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import voluptuous as vol
 
 from .api import NationalRailAPI
 from .const import (
     CONF_DESTINATION,
+    CONF_ENABLE_RECENT_TRAIN_TIMES,
     CONF_NIGHT_UPDATES,
+    CONF_NROD_PASSWORD,
+    CONF_NROD_USERNAME,
     CONF_NUM_SERVICES,
     CONF_ORIGIN,
     CONF_TIME_WINDOW,
     DOMAIN,
 )
 from .coordinator import NationalRailDataUpdateCoordinator
+from .corpus import CorpusError, CorpusReferenceStore
+from .journey_store import JourneyCorrelationEngine, RecentJourneysStore
+from .nrod_stomp import NrodFeedManager
 from .statistics import CommuteStatisticsStore
 
 SERVICE_GET_HISTORICAL_RAW_DATA = "get_historical_raw_data"
+SERVICE_GET_RECENT_JOURNEYS = "get_recent_journeys"
+
+FEED_DATA_KEY = f"{DOMAIN}_feed"
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+
+
+async def _async_setup_recent_train_times(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: NationalRailDataUpdateCoordinator,
+    config: dict,
+    session,
+) -> None:
+    """Set up the Recent Train Times feed subscription for a config entry.
+
+    Uses a single shared NrodFeedManager/CorpusReferenceStore across all
+    config entries (Network Rail's feed must not be opened more than once
+    per account). Any failure here is logged and swallowed so the entry's
+    core Darwin-based sensors keep working regardless of NROD feed health.
+    """
+    username = config.get(CONF_NROD_USERNAME)
+    password = config.get(CONF_NROD_PASSWORD)
+    if not username or not password:
+        _LOGGER.warning(
+            "Recent Train Times enabled for %s but NROD credentials are missing", entry.entry_id
+        )
+        return
+
+    try:
+        shared = hass.data.setdefault(FEED_DATA_KEY, {})
+        corpus_store: CorpusReferenceStore = shared.setdefault(
+            "corpus_store", CorpusReferenceStore(hass, session)
+        )
+        if "corpus_loaded" not in shared:
+            await corpus_store.async_load()
+            shared["corpus_loaded"] = True
+        await corpus_store.async_ensure_fresh(username, password)
+
+        feed_manager: NrodFeedManager = shared.setdefault(
+            "feed_manager", NrodFeedManager(hass, username, password)
+        )
+
+        journeys_store = RecentJourneysStore(hass, entry.entry_id)
+        await journeys_store.async_load()
+
+        engine = JourneyCorrelationEngine(
+            hass,
+            coordinator.origin,
+            coordinator.destination,
+            corpus_store.get_stanox_codes_for_crs(coordinator.origin),
+            corpus_store.get_stanox_codes_for_crs(coordinator.destination),
+            journeys_store,
+        )
+
+        await feed_manager.async_acquire(entry.entry_id, engine.handle_event, engine.watched_stanox)
+
+        coordinator.journeys_store = journeys_store
+        coordinator.feed_manager = feed_manager
+    except CorpusError as err:
+        _LOGGER.error(
+            "Recent Train Times unavailable for %s: %s", entry.entry_id, err
+        )
+    except Exception:  # noqa: BLE001 - never let feed setup break the core integration
+        _LOGGER.exception(
+            "Unexpected error setting up Recent Train Times for %s", entry.entry_id
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -71,6 +141,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await stats_store.async_load()
         coordinator.stats_store = stats_store
 
+        # Set up Recent Train Times (Network Rail Open Data feed), if enabled.
+        # This is best-effort: any failure here must never prevent the core
+        # Darwin-based sensors from working.
+        if config.get(CONF_ENABLE_RECENT_TRAIN_TIMES) and config.get(CONF_DESTINATION):
+            await _async_setup_recent_train_times(hass, entry, coordinator, config, session)
+
         # Fetch initial data
         _LOGGER.debug("Fetching initial data for %s -> %s", config.get(CONF_ORIGIN), config.get(CONF_DESTINATION))
         await coordinator.async_config_entry_first_refresh()
@@ -104,6 +180,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 supports_response=SupportsResponse.ONLY,
             )
 
+        if not hass.services.has_service(DOMAIN, SERVICE_GET_RECENT_JOURNEYS):
+            async def _handle_get_recent_journeys(call: ServiceCall) -> dict:
+                entry_id = call.data["entry_id"]
+                if entry_id not in hass.data.get(DOMAIN, {}):
+                    raise ServiceValidationError(
+                        f"No commute found with entry_id: {entry_id}"
+                    )
+                target_coordinator = hass.data[DOMAIN][entry_id]
+                if target_coordinator.journeys_store is None:
+                    raise ServiceValidationError(
+                        f"Recent Train Times is not enabled for entry_id: {entry_id}"
+                    )
+                limit = call.data.get("limit", 20)
+                return {"journeys": target_coordinator.journeys_store.get_recent_journeys(limit)}
+
+            hass.services.async_register(
+                DOMAIN,
+                SERVICE_GET_RECENT_JOURNEYS,
+                _handle_get_recent_journeys,
+                schema=vol.Schema(
+                    {
+                        vol.Required("entry_id"): cv.string,
+                        vol.Optional("limit", default=20): vol.All(
+                            vol.Coerce(int), vol.Range(min=1, max=500)
+                        ),
+                    }
+                ),
+                supports_response=SupportsResponse.ONLY,
+            )
+
         _LOGGER.debug("My Rail Commute integration setup complete")
 
         return True
@@ -131,11 +237,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator = hass.data[DOMAIN][entry.entry_id]
         await coordinator.api.close()
 
+        # Release this entry's Recent Train Times feed subscription, if any.
+        # Tear down the shared feed/CORPUS resources once no entry uses them.
+        if coordinator.feed_manager is not None:
+            await coordinator.feed_manager.async_release(entry.entry_id)
+            if not coordinator.feed_manager.has_subscribers:
+                hass.data.pop(FEED_DATA_KEY, None)
+
         hass.data[DOMAIN].pop(entry.entry_id)
 
-        # Remove domain-wide service when the last entry is unloaded
+        # Remove domain-wide services when the last entry is unloaded
         if not hass.data[DOMAIN]:
             hass.services.async_remove(DOMAIN, SERVICE_GET_HISTORICAL_RAW_DATA)
+            hass.services.async_remove(DOMAIN, SERVICE_GET_RECENT_JOURNEYS)
 
     return unload_ok
 

--- a/custom_components/my_rail_commute/binary_sensor.py
+++ b/custom_components/my_rail_commute/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -18,6 +19,7 @@ from .const import (
     ATTR_CANCELLED_COUNT,
     ATTR_DELAYED_COUNT,
     ATTR_DISRUPTION_REASONS,
+    ATTR_FEED_LAST_MESSAGE_AT,
     ATTR_MAX_DELAY,
     CONF_COMMUTE_NAME,
     DOMAIN,
@@ -45,6 +47,10 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = [
         DisruptionSensor(coordinator, entry),
     ]
+
+    # Recent Train Times feed diagnostic, only when enabled
+    if coordinator.feed_manager is not None:
+        entities.append(NrodFeedConnectedBinarySensor(coordinator, entry))
 
     _LOGGER.debug(
         "Setting up binary sensor entities for %s -> %s",
@@ -178,3 +184,44 @@ class DisruptionSensor(NationalRailCommuteBinarySensor):
         if self.is_on:
             return "mdi:alert-circle"
         return "mdi:check-circle"
+
+
+class NrodFeedConnectedBinarySensor(NationalRailCommuteBinarySensor):
+    """Diagnostic binary sensor for the Network Rail Open Data feed connection.
+
+    Lets users tell whether Recent Train Times is actually receiving data,
+    since the feed connection is independent of the Darwin-based polling
+    that powers the rest of the integration.
+    """
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the feed connectivity sensor.
+
+        Args:
+            coordinator: Data coordinator
+            entry: Config entry
+        """
+        super().__init__(coordinator, entry)
+
+        self._attr_name = "Recent Train Times Feed Connected"
+        self._attr_unique_id = f"{entry.entry_id}_nrod_feed_connected"
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the shared NROD STOMP feed is connected."""
+        feed_manager = self.coordinator.feed_manager
+        return feed_manager is not None and feed_manager.connected
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the timestamp of the last message received from the feed."""
+        feed_manager = self.coordinator.feed_manager
+        return {
+            ATTR_FEED_LAST_MESSAGE_AT: feed_manager.last_message_at if feed_manager else None,
+        }

--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -7,14 +7,13 @@ import math
 from pathlib import Path
 from typing import Any
 
-import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import voluptuous as vol
 
 from .api import (
     AuthenticationError,
@@ -28,17 +27,20 @@ from .const import (
     CONF_COMMUTE_NAME,
     CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
-    CONF_DISRUPTION_MULTIPLE_COUNT,
     CONF_DISRUPTION_MULTIPLE_DELAY,
     CONF_DISRUPTION_SINGLE_DELAY,
+    CONF_ENABLE_RECENT_TRAIN_TIMES,
     CONF_MAJOR_DELAY_THRESHOLD,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
+    CONF_NROD_PASSWORD,
+    CONF_NROD_USERNAME,
     CONF_NUM_SERVICES,
     CONF_ORIGIN,
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
     DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
+    DEFAULT_ENABLE_RECENT_TRAIN_TIMES,
     DEFAULT_MAJOR_DELAY_THRESHOLD,
     DEFAULT_MINOR_DELAY_THRESHOLD,
     DEFAULT_NAME,
@@ -58,6 +60,7 @@ from .const import (
     MIN_NUM_SERVICES,
     MIN_TIME_WINDOW,
 )
+from .corpus import CorpusAuthenticationError, CorpusError, CorpusReferenceStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -152,6 +155,23 @@ async def validate_stations(
     }
 
 
+async def validate_nrod_credentials(hass: HomeAssistant, username: str, password: str) -> None:
+    """Validate Network Rail Open Data credentials.
+
+    Args:
+        hass: Home Assistant instance
+        username: NROD account username
+        password: NROD account password
+
+    Raises:
+        CorpusAuthenticationError: If authentication fails
+        CorpusError: For other connectivity errors
+    """
+    session = async_get_clientsession(hass)
+    corpus_store = CorpusReferenceStore(hass, session)
+    await corpus_store.async_test_credentials(username, password)
+
+
 def validate_delay_thresholds(
     severe: int,
     major: int,
@@ -196,6 +216,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._minor_delay_threshold: int | None = None
         self._departed_train_grace_period: int | None = None
         self._nearby_stations: list[tuple[float, dict]] | None = None
+        self._enable_recent_train_times: bool = False
+        self._nrod_username: str | None = None
+        self._nrod_password: str | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -413,6 +436,12 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_thresholds"
                 _LOGGER.error("Invalid delay thresholds: %s", err)
 
+            enable_recent_train_times = bool(
+                user_input.get(CONF_ENABLE_RECENT_TRAIN_TIMES, False)
+            )
+            if enable_recent_train_times and self._all_departures:
+                errors["base"] = "recent_train_times_needs_destination"
+
             if not errors:
                 # Store settings in instance variables
                 if self._all_departures:
@@ -429,6 +458,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._departed_train_grace_period = user_input.get(
                     CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD
                 )
+                self._enable_recent_train_times = enable_recent_train_times
 
                 # Set unique ID based on route (all-departures gets a distinct suffix)
                 if self._all_departures:
@@ -437,6 +467,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     unique_id = f"{self._origin}_{self._destination}"
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
+
+                if self._enable_recent_train_times:
+                    return await self.async_step_nrod_credentials()
 
                 # Skip return-journey step when showing all departures
                 if self._all_departures:
@@ -531,6 +564,10 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         mode=selector.NumberSelectorMode.SLIDER,
                     ),
                 ),
+                vol.Optional(
+                    CONF_ENABLE_RECENT_TRAIN_TIMES,
+                    default=DEFAULT_ENABLE_RECENT_TRAIN_TIMES,
+                ): selector.BooleanSelector(),
             }
         )
 
@@ -543,6 +580,77 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "destination": self._destination_name or "All destinations",
             },
         )
+
+    async def async_step_nrod_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Collect (or reuse) Network Rail Open Data credentials.
+
+        Only entered when Recent Train Times has been enabled for this
+        route. NROD credentials are account-wide, so if another entry
+        already has them configured they're reused silently, exactly like
+        the Rail Data Marketplace API key.
+
+        Args:
+            user_input: User input data
+
+        Returns:
+            FlowResult for the next step
+        """
+        existing_entries = self._async_current_entries()
+        for existing_entry in existing_entries:
+            existing_username = existing_entry.data.get(CONF_NROD_USERNAME)
+            existing_password = existing_entry.data.get(CONF_NROD_PASSWORD)
+            if existing_username and existing_password:
+                _LOGGER.debug("Reusing NROD credentials from existing integration")
+                self._nrod_username = existing_username
+                self._nrod_password = existing_password
+                return await self._async_next_step_after_nrod()
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                await validate_nrod_credentials(
+                    self.hass,
+                    user_input[CONF_NROD_USERNAME],
+                    user_input[CONF_NROD_PASSWORD],
+                )
+
+                self._nrod_username = user_input[CONF_NROD_USERNAME]
+                self._nrod_password = user_input[CONF_NROD_PASSWORD]
+
+                return await self._async_next_step_after_nrod()
+
+            except CorpusAuthenticationError:
+                errors["base"] = "invalid_nrod_auth"
+            except CorpusError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="nrod_credentials",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_NROD_USERNAME): str,
+                    vol.Required(CONF_NROD_PASSWORD): selector.TextSelector(
+                        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+                    ),
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "signup_url": "https://publicdatafeeds.networkrail.co.uk/",
+            },
+        )
+
+    async def _async_next_step_after_nrod(self) -> FlowResult:
+        """Continue the flow after NROD credentials are settled."""
+        if self._all_departures:
+            return self._create_entry()
+        return await self.async_step_return_journey()
 
     async def async_step_return_journey(
         self, user_input: dict[str, Any] | None = None
@@ -582,6 +690,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
                             CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
                             CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
+                            CONF_ENABLE_RECENT_TRAIN_TIMES: self._enable_recent_train_times,
+                            CONF_NROD_USERNAME: self._nrod_username,
+                            CONF_NROD_PASSWORD: self._nrod_password,
                         },
                     )
                 )
@@ -637,9 +748,13 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
             CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
             CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
+            CONF_ENABLE_RECENT_TRAIN_TIMES: self._enable_recent_train_times,
         }
         if self._destination:
             data[CONF_DESTINATION] = self._destination
+        if self._enable_recent_train_times:
+            data[CONF_NROD_USERNAME] = self._nrod_username
+            data[CONF_NROD_PASSWORD] = self._nrod_password
         return self.async_create_entry(title=self._commute_name, data=data)
 
     @staticmethod
@@ -674,6 +789,10 @@ class NationalRailCommuteOptionsFlow(config_entries.OptionsFlow):
         """
         errors: dict[str, str] = {}
 
+        # Get current values
+        current_data = self.config_entry.data
+        options = self.config_entry.options
+
         if user_input is not None:
             # Validate delay thresholds
             try:
@@ -686,13 +805,37 @@ class NationalRailCommuteOptionsFlow(config_entries.OptionsFlow):
                 errors["base"] = "invalid_thresholds"
                 _LOGGER.error("Invalid delay thresholds: %s", err)
 
-            if not errors:
-                # Update the config entry
-                return self.async_create_entry(title="", data=user_input)
+            enable_recent_train_times = bool(
+                user_input.get(CONF_ENABLE_RECENT_TRAIN_TIMES, False)
+            )
+            has_destination = bool(current_data.get(CONF_DESTINATION))
+            if enable_recent_train_times and not has_destination:
+                errors["base"] = "recent_train_times_needs_destination"
 
-        # Get current values
-        current_data = self.config_entry.data
-        options = self.config_entry.options
+            # A blank password in the form means "keep the existing one" so
+            # users aren't forced to re-enter it every time they open options.
+            existing_username = options.get(
+                CONF_NROD_USERNAME, current_data.get(CONF_NROD_USERNAME)
+            )
+            existing_password = options.get(
+                CONF_NROD_PASSWORD, current_data.get(CONF_NROD_PASSWORD)
+            )
+            nrod_username = user_input.get(CONF_NROD_USERNAME) or existing_username
+            nrod_password = user_input.get(CONF_NROD_PASSWORD) or existing_password
+
+            if enable_recent_train_times and not (nrod_username and nrod_password) and not errors:
+                errors["base"] = "nrod_credentials_required"
+
+            if not errors:
+                data = dict(user_input)
+                if enable_recent_train_times:
+                    data[CONF_NROD_USERNAME] = nrod_username
+                    data[CONF_NROD_PASSWORD] = nrod_password
+                else:
+                    data.pop(CONF_NROD_USERNAME, None)
+                    data.pop(CONF_NROD_PASSWORD, None)
+                # Update the config entry
+                return self.async_create_entry(title="", data=data)
 
         data_schema = vol.Schema(
             {
@@ -799,6 +942,24 @@ class NationalRailCommuteOptionsFlow(config_entries.OptionsFlow):
                         unit_of_measurement="minutes",
                         mode=selector.NumberSelectorMode.SLIDER,
                     ),
+                ),
+                vol.Optional(
+                    CONF_ENABLE_RECENT_TRAIN_TIMES,
+                    default=options.get(
+                        CONF_ENABLE_RECENT_TRAIN_TIMES,
+                        current_data.get(
+                            CONF_ENABLE_RECENT_TRAIN_TIMES, DEFAULT_ENABLE_RECENT_TRAIN_TIMES
+                        ),
+                    ),
+                ): selector.BooleanSelector(),
+                vol.Optional(
+                    CONF_NROD_USERNAME,
+                    default=options.get(
+                        CONF_NROD_USERNAME, current_data.get(CONF_NROD_USERNAME, "")
+                    ),
+                ): str,
+                vol.Optional(CONF_NROD_PASSWORD, default=""): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
                 ),
             }
         )

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -163,3 +163,47 @@ ATTR_REVERSE_AVG_DELAY_7D: Final = "reverse_avg_delay_7day"
 ATTR_REVERSE_WORST_DAY: Final = "reverse_worst_day"
 ATTR_REVERSE_BEST_DAY: Final = "reverse_best_day"
 ATTR_REVERSE_DAILY_BREAKDOWN: Final = "reverse_daily_breakdown"
+
+# Recent Train Times (Network Rail Open Data / NROD feed) configuration
+CONF_ENABLE_RECENT_TRAIN_TIMES: Final = "enable_recent_train_times"
+CONF_NROD_USERNAME: Final = "nrod_username"
+CONF_NROD_PASSWORD: Final = "nrod_password"
+
+DEFAULT_ENABLE_RECENT_TRAIN_TIMES: Final = False
+
+NROD_STOMP_HOST: Final = "publicdatafeeds.networkrail.co.uk"
+NROD_STOMP_SSL_PORT: Final = 61618
+NROD_STOMP_TOPIC: Final = "/topic/TRAIN_MVT_ALL_TOC"
+NROD_CORPUS_URL: Final = (
+    "https://publicdatafeeds.networkrail.co.uk/ntrod/SupportingFileAuthenticate?type=CORPUS"
+)
+
+NROD_RECONNECT_INITIAL_DELAY: Final = 5  # seconds
+NROD_RECONNECT_MAX_DELAY: Final = 300  # seconds
+NROD_RECONNECT_BACKOFF_FACTOR: Final = 2
+
+# Journey correlation
+JOURNEY_CORRELATION_MAX_MINUTES: Final = 240  # max plausible transit time to pair dep/arr
+JOURNEY_ARRIVAL_GRACE_MINUTES: Final = 5  # fallback window to accept a PASS instead of ARRIVAL
+JOURNEY_PENDING_TIMEOUT_MINUTES: Final = 360  # discard an unmatched departure after this long
+RECENT_JOURNEYS_RETENTION_DAYS: Final = 14
+RECENT_JOURNEYS_MAX_STORED: Final = 500
+RECENT_JOURNEYS_STORAGE_VERSION: Final = 1
+CORPUS_STORAGE_VERSION: Final = 1
+CORPUS_REFRESH_INTERVAL_DAYS: Final = 7
+
+# Sensor type
+SENSOR_RECENT_TRAIN_TIMES: Final = "recent_train_times"
+
+# Attributes — recent train times
+ATTR_RECENT_JOURNEYS: Final = "recent_journeys"
+ATTR_LAST_JOURNEY: Final = "last_journey"
+ATTR_JOURNEYS_RECORDED_TODAY: Final = "journeys_recorded_today"
+ATTR_FEED_CONNECTED: Final = "feed_connected"
+ATTR_FEED_LAST_MESSAGE_AT: Final = "feed_last_message_at"
+
+# NROD error messages
+ERROR_NROD_AUTH: Final = (
+    "Network Rail Open Data authentication failed. Please check your NROD username/password."
+)
+ERROR_NROD_UNAVAILABLE: Final = "Network Rail Open Data feed is currently unavailable."

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta
 import logging
 import re
-from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -16,7 +16,6 @@ from .const import (
     CONF_ALL_DEPARTURES,
     CONF_DEPARTED_TRAIN_GRACE_PERIOD,
     CONF_DESTINATION,
-    CONF_DISRUPTION_MULTIPLE_COUNT,
     CONF_DISRUPTION_MULTIPLE_DELAY,
     CONF_DISRUPTION_SINGLE_DELAY,
     CONF_MAJOR_DELAY_THRESHOLD,
@@ -130,6 +129,11 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Historical stats recorder — attached externally by async_setup_entry
         self.stats_store: Any | None = None
+
+        # Recent Train Times (Network Rail Open Data feed) — attached
+        # externally by async_setup_entry only when the feature is enabled
+        self.journeys_store: Any | None = None
+        self.feed_manager: Any | None = None
 
         # Initialize with off-peak interval
         update_interval = self._get_update_interval()

--- a/custom_components/my_rail_commute/corpus.py
+++ b/custom_components/my_rail_commute/corpus.py
@@ -1,0 +1,209 @@
+"""CORPUS reference data (CRS <-> STANOX resolution) for the Network Rail Open Data feed."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import aiohttp
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    CORPUS_REFRESH_INTERVAL_DAYS,
+    CORPUS_STORAGE_VERSION,
+    DOMAIN,
+    NROD_CORPUS_URL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT = 30
+
+
+class CorpusError(Exception):
+    """Base exception for CORPUS reference data errors."""
+
+
+class CorpusAuthenticationError(CorpusError):
+    """NROD credentials were rejected."""
+
+
+class CorpusUnavailableError(CorpusError):
+    """CORPUS data could not be fetched and no cached copy is available."""
+
+
+class CorpusReferenceStore:
+    """Resolves CRS codes to STANOX codes using Network Rail's CORPUS reference data.
+
+    CORPUS data is fetched once via HTTP (Basic Auth, using the same NROD
+    account as the STOMP feed) and cached locally, since it changes rarely.
+    """
+
+    def __init__(self, hass: HomeAssistant, session: aiohttp.ClientSession) -> None:
+        """Initialize the store.
+
+        Args:
+            hass: Home Assistant instance
+            session: aiohttp client session
+        """
+        self._hass = hass
+        self._session = session
+        self._store = Store(hass, CORPUS_STORAGE_VERSION, f"{DOMAIN}_corpus")
+        self._crs_to_stanox: dict[str, list[str]] = {}
+        self._stanox_to_crs: dict[str, str] = {}
+        self._fetched_at: str | None = None
+
+    async def async_load(self) -> None:
+        """Load any cached CORPUS data from storage."""
+        raw = await self._store.async_load()
+        if raw is None:
+            return
+        self._crs_to_stanox = raw.get("crs_to_stanox", {})
+        self._stanox_to_crs = raw.get("stanox_to_crs", {})
+        self._fetched_at = raw.get("fetched_at")
+        _LOGGER.debug(
+            "Loaded cached CORPUS data (%d stations, fetched %s)",
+            len(self._crs_to_stanox),
+            self._fetched_at,
+        )
+
+    def _is_stale(self) -> bool:
+        """Return True if the cached data is missing or too old to trust."""
+        if not self._crs_to_stanox or not self._fetched_at:
+            return True
+        fetched_at = dt_util.parse_datetime(self._fetched_at)
+        if fetched_at is None:
+            return True
+        age = dt_util.utcnow() - fetched_at
+        return age.days >= CORPUS_REFRESH_INTERVAL_DAYS
+
+    async def async_ensure_fresh(self, username: str, password: str) -> None:
+        """Refresh CORPUS data if the cache is missing or stale.
+
+        On fetch failure: keep serving a stale cache if one exists (with a
+        warning); raise CorpusUnavailableError only if there is no cache at
+        all, so callers can disable the feature for that entry gracefully.
+
+        Args:
+            username: NROD account username
+            password: NROD account password
+
+        Raises:
+            CorpusUnavailableError: If refresh fails and no cache exists
+        """
+        if not self._is_stale():
+            return
+
+        try:
+            await self._async_fetch_and_store(username, password)
+        except CorpusError:
+            if self._crs_to_stanox:
+                _LOGGER.warning(
+                    "Failed to refresh CORPUS reference data; continuing with stale cache"
+                )
+                return
+            raise
+
+    async def _async_fetch_and_store(self, username: str, password: str) -> None:
+        """Fetch CORPUS data from NROD and persist it to storage."""
+        crs_to_stanox, stanox_to_crs = await self._async_fetch(username, password)
+
+        self._crs_to_stanox = crs_to_stanox
+        self._stanox_to_crs = stanox_to_crs
+        self._fetched_at = dt_util.utcnow().isoformat()
+
+        await self._store.async_save(
+            {
+                "crs_to_stanox": self._crs_to_stanox,
+                "stanox_to_crs": self._stanox_to_crs,
+                "fetched_at": self._fetched_at,
+            }
+        )
+        _LOGGER.debug("Refreshed CORPUS data (%d stations)", len(self._crs_to_stanox))
+
+    async def _async_fetch(
+        self, username: str, password: str
+    ) -> tuple[dict[str, list[str]], dict[str, str]]:
+        """Fetch and parse the raw CORPUS JSON file from NROD.
+
+        Returns:
+            Tuple of (crs -> list of stanox codes, stanox -> crs)
+
+        Raises:
+            CorpusAuthenticationError: If NROD rejects the credentials
+            CorpusUnavailableError: For any other fetch/parse failure
+        """
+        try:
+            async with self._session.get(
+                NROD_CORPUS_URL,
+                auth=aiohttp.BasicAuth(username, password),
+                timeout=aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT),
+            ) as response:
+                if response.status == 401:
+                    raise CorpusAuthenticationError("NROD authentication failed")
+                if response.status != 200:
+                    raise CorpusUnavailableError(
+                        f"CORPUS download failed with status {response.status}"
+                    )
+                data = await response.json(content_type=None)
+        except CorpusError:
+            raise
+        except aiohttp.ClientError as err:
+            raise CorpusUnavailableError(f"Network error fetching CORPUS data: {err}") from err
+        except (ValueError, TypeError) as err:
+            raise CorpusUnavailableError(f"Invalid CORPUS response: {err}") from err
+
+        return self._parse_corpus(data)
+
+    @staticmethod
+    def _parse_corpus(data: dict[str, Any]) -> tuple[dict[str, list[str]], dict[str, str]]:
+        """Parse the CORPUS TIPLOCDATA array into CRS/STANOX lookup tables."""
+        crs_to_stanox: dict[str, list[str]] = {}
+        stanox_to_crs: dict[str, str] = {}
+
+        for entry in data.get("TIPLOCDATA", []):
+            crs = (entry.get("3ALPHA") or "").strip().upper()
+            stanox = (entry.get("STANOX") or "").strip()
+
+            if not crs or not stanox:
+                continue
+
+            crs_to_stanox.setdefault(crs, [])
+            if stanox not in crs_to_stanox[crs]:
+                crs_to_stanox[crs].append(stanox)
+            stanox_to_crs.setdefault(stanox, crs)
+
+        return crs_to_stanox, stanox_to_crs
+
+    def get_stanox_codes_for_crs(self, crs: str) -> set[str]:
+        """Return the set of STANOX codes associated with a CRS code."""
+        return set(self._crs_to_stanox.get(crs.upper(), []))
+
+    def get_crs_for_stanox(self, stanox: str) -> str | None:
+        """Return the CRS code for a STANOX code, if known."""
+        return self._stanox_to_crs.get(stanox)
+
+    async def async_test_credentials(self, username: str, password: str) -> None:
+        """Validate NROD credentials without establishing a STOMP connection.
+
+        Raises:
+            CorpusAuthenticationError: If the credentials are rejected
+            CorpusUnavailableError: For any other connectivity failure
+        """
+        try:
+            async with self._session.get(
+                NROD_CORPUS_URL,
+                auth=aiohttp.BasicAuth(username, password),
+                timeout=aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT),
+            ) as response:
+                if response.status == 401:
+                    raise CorpusAuthenticationError("NROD authentication failed")
+                if response.status != 200:
+                    raise CorpusUnavailableError(
+                        f"NROD credential check failed with status {response.status}"
+                    )
+        except CorpusError:
+            raise
+        except aiohttp.ClientError as err:
+            raise CorpusUnavailableError(f"Network error validating NROD credentials: {err}") from err

--- a/custom_components/my_rail_commute/journey_store.py
+++ b/custom_components/my_rail_commute/journey_store.py
@@ -1,0 +1,251 @@
+"""Journey correlation and persistence for the Recent Train Times feature.
+
+Pairs "departed origin" and "arrived destination" movement events for the
+same train on the same day into a completed journey record, and persists a
+rolling log of those records per config entry.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DOMAIN,
+    JOURNEY_CORRELATION_MAX_MINUTES,
+    JOURNEY_PENDING_TIMEOUT_MINUTES,
+    RECENT_JOURNEYS_MAX_STORED,
+    RECENT_JOURNEYS_RETENTION_DAYS,
+    RECENT_JOURNEYS_STORAGE_VERSION,
+)
+from .nrod_stomp import (
+    EVENT_ARRIVAL,
+    EVENT_DEPARTURE,
+    EVENT_PASS,
+    CancellationEvent,
+    MovementEvent,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RecentJourneysStore:
+    """Persistent rolling log of recent completed/cancelled journeys for one route."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Initialize the store.
+
+        Args:
+            hass: Home Assistant instance
+            entry_id: Config entry ID this log belongs to
+        """
+        self._store = Store(
+            hass, RECENT_JOURNEYS_STORAGE_VERSION, f"{DOMAIN}_{entry_id}_journeys"
+        )
+        self._journeys: list[dict[str, Any]] = []
+
+    async def async_load(self) -> None:
+        """Load any persisted journeys from storage."""
+        raw = await self._store.async_load()
+        self._journeys = raw.get("journeys", []) if raw else []
+        self._prune()
+        _LOGGER.debug("Loaded %d recent journeys", len(self._journeys))
+
+    async def async_add_journey(self, record: dict[str, Any]) -> None:
+        """Append a completed or cancelled journey record and persist it."""
+        self._journeys.append(record)
+        self._journeys.sort(key=lambda j: j.get("recorded_at", ""))
+        self._prune()
+        await self._store.async_save({"journeys": self._journeys})
+        _LOGGER.debug(
+            "Recorded journey: train_id=%s cancelled=%s delay=%s",
+            record.get("train_id"),
+            record.get("is_cancelled"),
+            record.get("delay_minutes"),
+        )
+
+    def get_recent_journeys(self, limit: int = 20) -> list[dict[str, Any]]:
+        """Return the most recent journeys, newest first."""
+        return list(reversed(self._journeys[-limit:]))
+
+    def get_last_journey(self) -> dict[str, Any] | None:
+        """Return the most recently recorded journey, or None."""
+        return self._journeys[-1] if self._journeys else None
+
+    def count_for_date(self, service_date: str) -> int:
+        """Return how many journeys were recorded for a given service date."""
+        return sum(1 for j in self._journeys if j.get("service_date") == service_date)
+
+    def _prune(self) -> None:
+        """Remove entries beyond the retention window or storage cap."""
+        cutoff = (
+            dt_util.now().date() - timedelta(days=RECENT_JOURNEYS_RETENTION_DAYS)
+        ).isoformat()
+        before = len(self._journeys)
+        self._journeys = [j for j in self._journeys if j.get("service_date", "") >= cutoff]
+        if len(self._journeys) > RECENT_JOURNEYS_MAX_STORED:
+            self._journeys = self._journeys[-RECENT_JOURNEYS_MAX_STORED:]
+        if len(self._journeys) != before:
+            _LOGGER.debug(
+                "Pruned recent journeys log: %d -> %d entries", before, len(self._journeys)
+            )
+
+
+class JourneyCorrelationEngine:
+    """Correlates origin/destination movement events into journey records."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        origin_crs: str,
+        destination_crs: str,
+        origin_stanox: set[str],
+        destination_stanox: set[str],
+        journeys_store: RecentJourneysStore,
+    ) -> None:
+        """Initialize the engine for a single route.
+
+        Args:
+            hass: Home Assistant instance
+            origin_crs: Origin station CRS code
+            destination_crs: Destination station CRS code
+            origin_stanox: STANOX codes that count as "departed the origin"
+            destination_stanox: STANOX codes that count as "arrived at the destination"
+            journeys_store: Store to persist completed journeys into
+        """
+        self._hass = hass
+        self._origin_crs = origin_crs
+        self._destination_crs = destination_crs
+        self._origin_stanox = set(origin_stanox)
+        self._destination_stanox = set(destination_stanox)
+        self._journeys_store = journeys_store
+        # Keyed by (train_id, service_date): headcodes are reused daily, so
+        # service_date must be part of the key to avoid cross-day mismatches.
+        self._pending: dict[tuple[str, str], dict[str, Any]] = {}
+
+    @property
+    def watched_stanox(self) -> set[str]:
+        """Return every STANOX code this engine needs feed events for."""
+        return self._origin_stanox | self._destination_stanox
+
+    async def handle_event(self, event: MovementEvent | CancellationEvent) -> None:
+        """Process a single feed event, dispatching by type."""
+        self._expire_stale_pending()
+        if isinstance(event, MovementEvent):
+            await self._handle_movement(event)
+        elif isinstance(event, CancellationEvent):
+            await self._handle_cancellation(event)
+
+    async def _handle_movement(self, event: MovementEvent) -> None:
+        key = (event.train_id, event.service_date)
+
+        if event.stanox in self._origin_stanox and event.event_type == EVENT_DEPARTURE:
+            if key in self._pending:
+                return  # duplicate/redelivered departure message, ignore
+            self._pending[key] = {
+                "train_id": event.train_id,
+                "service_date": event.service_date,
+                "toc": event.toc,
+                "scheduled_departure": event.planned_time,
+                "actual_departure": event.actual_time,
+                "departure_platform": event.platform,
+                "recorded_at_dt": dt_util.utcnow(),
+                "arrival_seen": False,
+                "completed": False,
+            }
+            return
+
+        if event.stanox in self._destination_stanox and event.event_type in (
+            EVENT_ARRIVAL,
+            EVENT_PASS,
+        ):
+            await self._handle_arrival_candidate(key, event)
+
+    async def _handle_arrival_candidate(
+        self, key: tuple[str, str], event: MovementEvent
+    ) -> None:
+        pending = self._pending.get(key)
+        if pending is None or pending["completed"]:
+            return  # no matching departure on record, or already completed
+
+        elapsed_minutes = (
+            dt_util.utcnow() - pending["recorded_at_dt"]
+        ).total_seconds() / 60
+        if elapsed_minutes > JOURNEY_CORRELATION_MAX_MINUTES:
+            _LOGGER.debug(
+                "Discarding pending departure %s: exceeded max correlation window", key
+            )
+            del self._pending[key]
+            return
+
+        if event.event_type == EVENT_PASS and pending["arrival_seen"]:
+            return  # a real ARRIVAL already completed this journey
+
+        if event.event_type == EVENT_ARRIVAL:
+            pending["arrival_seen"] = True
+
+        pending["completed"] = True
+        record = {
+            "train_id": pending["train_id"],
+            "service_date": pending["service_date"],
+            "toc": pending["toc"],
+            "origin_crs": self._origin_crs,
+            "destination_crs": self._destination_crs,
+            "scheduled_departure": pending["scheduled_departure"],
+            "actual_departure": pending["actual_departure"],
+            "departure_platform": pending["departure_platform"],
+            "scheduled_arrival": event.planned_time,
+            "actual_arrival": event.actual_time,
+            "arrival_platform": event.platform,
+            "delay_minutes": event.delay_minutes,
+            "is_cancelled": False,
+            "cancellation_reason": None,
+            "cancelled_at": None,
+            "recorded_at": dt_util.utcnow().isoformat(),
+        }
+        del self._pending[key]
+        await self._journeys_store.async_add_journey(record)
+
+    async def _handle_cancellation(self, event: CancellationEvent) -> None:
+        key = (event.train_id, event.service_date)
+        pending = self._pending.pop(key, None)
+
+        # Only record a cancellation relevant to this route: either we already
+        # saw the train depart the origin, or the cancellation is itself
+        # reported at the origin station.
+        if pending is None and event.stanox not in self._origin_stanox:
+            return
+
+        record = {
+            "train_id": event.train_id,
+            "service_date": event.service_date,
+            "toc": pending.get("toc") if pending else None,
+            "origin_crs": self._origin_crs,
+            "destination_crs": self._destination_crs,
+            "scheduled_departure": pending.get("scheduled_departure") if pending else None,
+            "actual_departure": pending.get("actual_departure") if pending else None,
+            "departure_platform": pending.get("departure_platform") if pending else None,
+            "scheduled_arrival": None,
+            "actual_arrival": None,
+            "arrival_platform": None,
+            "delay_minutes": None,
+            "is_cancelled": True,
+            "cancellation_reason": event.reason_code,
+            "cancelled_at": "en_route" if pending else "origin",
+            "recorded_at": dt_util.utcnow().isoformat(),
+        }
+        await self._journeys_store.async_add_journey(record)
+
+    def _expire_stale_pending(self) -> None:
+        """Discard unmatched departures that have been pending too long."""
+        cutoff = dt_util.utcnow() - timedelta(minutes=JOURNEY_PENDING_TIMEOUT_MINUTES)
+        stale_keys = [
+            key for key, value in self._pending.items() if value["recorded_at_dt"] < cutoff
+        ]
+        for key in stale_keys:
+            _LOGGER.debug("Discarding unmatched pending departure (timed out): %s", key)
+            del self._pending[key]

--- a/custom_components/my_rail_commute/manifest.json
+++ b/custom_components/my_rail_commute/manifest.json
@@ -11,7 +11,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/adamf83/my-rail-commute/issues",
   "requirements": [
-    "aiohttp>=3.9.0"
+    "aiohttp>=3.9.0",
+    "stomp.py>=8.1.0,<9"
   ],
-  "version": "1.1.5"
+  "version": "1.2.0"
 }

--- a/custom_components/my_rail_commute/nrod_stomp.py
+++ b/custom_components/my_rail_commute/nrod_stomp.py
@@ -1,0 +1,391 @@
+"""Shared Network Rail Open Data (NROD) STOMP feed manager.
+
+Bridges stomp.py's thread/callback-based STOMP client into Home Assistant's
+asyncio event loop. There must only ever be one connection per NROD account
+(the feed provider's docs warn against concurrent connections), so this
+manager is a single shared, ref-counted resource used across every config
+entry that opts into Recent Train Times.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+import json
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+import stomp
+
+from .const import (
+    NROD_RECONNECT_BACKOFF_FACTOR,
+    NROD_RECONNECT_INITIAL_DELAY,
+    NROD_RECONNECT_MAX_DELAY,
+    NROD_STOMP_HOST,
+    NROD_STOMP_SSL_PORT,
+    NROD_STOMP_TOPIC,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+EVENT_ARRIVAL = "ARRIVAL"
+EVENT_DEPARTURE = "DEPARTURE"
+EVENT_PASS = "PASS"
+
+_MOVEMENT_MSG_TYPE = "0003"
+_CANCELLATION_MSG_TYPE = "0002"
+
+
+@dataclass
+class MovementEvent:
+    """A single train movement report (arrival/departure/pass) at a location."""
+
+    train_id: str
+    service_date: str  # YYYY-MM-DD, derived from the event's own timestamp
+    stanox: str
+    event_type: str  # ARRIVAL / DEPARTURE / PASS
+    planned_time: str | None
+    actual_time: str | None
+    platform: str | None
+    toc: str | None
+    variation_status: str | None
+    delay_minutes: int
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class CancellationEvent:
+    """A train cancellation report."""
+
+    train_id: str
+    service_date: str
+    stanox: str | None
+    reason_code: str | None
+    cancelled_at_origin: bool
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+Callback = Callable[["MovementEvent | CancellationEvent"], "Awaitable[None] | None"]
+
+
+def _epoch_ms_to_iso(value: Any) -> str | None:
+    """Convert an NROD epoch-milliseconds timestamp string to an ISO datetime string."""
+    if not value:
+        return None
+    try:
+        return dt_util.utc_from_timestamp(int(value) / 1000).isoformat()
+    except (TypeError, ValueError):
+        return None
+
+
+def _date_from_iso(value: str | None) -> str | None:
+    """Extract the YYYY-MM-DD date component from an ISO datetime string."""
+    if not value:
+        return None
+    return value[:10]
+
+
+def parse_stomp_frame(body: str) -> list[MovementEvent | CancellationEvent]:
+    """Parse a TRAIN_MVT_ALL_TOC STOMP frame body into typed events.
+
+    The feed delivers a JSON array of records shaped like
+    {"header": {"msg_type": "0003"}, "body": {...}}. Unrecognised message
+    types and malformed records are skipped rather than raising, since the
+    feed is high-volume and continuous — a single bad record must never take
+    down the connection.
+    """
+    events: list[MovementEvent | CancellationEvent] = []
+
+    try:
+        records = json.loads(body)
+    except (ValueError, TypeError):
+        _LOGGER.debug("Discarding malformed NROD STOMP frame (invalid JSON)")
+        return events
+
+    if not isinstance(records, list):
+        return events
+
+    for record in records:
+        try:
+            event = _parse_record(record)
+        except (KeyError, TypeError, ValueError) as err:
+            _LOGGER.debug("Discarding malformed NROD movement record: %s", err)
+            continue
+        if event is not None:
+            events.append(event)
+
+    return events
+
+
+def _parse_record(record: dict[str, Any]) -> MovementEvent | CancellationEvent | None:
+    """Parse a single record's header/body into a typed event, if recognised."""
+    if not isinstance(record, dict):
+        return None
+
+    header = record.get("header", {})
+    msg_type = header.get("msg_type")
+    body = record.get("body", {})
+
+    if not isinstance(body, dict):
+        return None
+
+    if msg_type == _MOVEMENT_MSG_TYPE:
+        return _parse_movement(body)
+    if msg_type == _CANCELLATION_MSG_TYPE:
+        return _parse_cancellation(body)
+    return None
+
+
+def _parse_movement(body: dict[str, Any]) -> MovementEvent | None:
+    """Parse a TRUST movement message body into a MovementEvent."""
+    event_type = str(body.get("event_type") or "").upper()
+    if event_type not in (EVENT_ARRIVAL, EVENT_DEPARTURE, EVENT_PASS):
+        return None
+
+    train_id = body.get("train_id")
+    stanox = body.get("loc_stanox")
+    if not train_id or not stanox:
+        return None
+
+    planned_time = _epoch_ms_to_iso(body.get("planned_timestamp") or body.get("gbtt_timestamp"))
+    actual_time = _epoch_ms_to_iso(body.get("actual_timestamp"))
+    service_date = _date_from_iso(planned_time or actual_time)
+    if not service_date:
+        return None
+
+    variation_status = body.get("variation_status")
+    delay_minutes = 0
+    try:
+        raw_variation = int(body.get("timetable_variation") or 0)
+        delay_minutes = -raw_variation if variation_status == "EARLY" else raw_variation
+    except (TypeError, ValueError):
+        delay_minutes = 0
+
+    return MovementEvent(
+        train_id=str(train_id),
+        service_date=service_date,
+        stanox=str(stanox),
+        event_type=event_type,
+        planned_time=planned_time,
+        actual_time=actual_time,
+        platform=body.get("platform") or None,
+        toc=body.get("toc_id") or None,
+        variation_status=variation_status,
+        delay_minutes=delay_minutes,
+        raw=body,
+    )
+
+
+def _parse_cancellation(body: dict[str, Any]) -> CancellationEvent | None:
+    """Parse a TRUST cancellation message body into a CancellationEvent."""
+    train_info = body.get("train_info", body)
+    train_id = train_info.get("train_id")
+    if not train_id:
+        return None
+
+    dep_time = _epoch_ms_to_iso(train_info.get("dep_timestamp"))
+    canx_time = _epoch_ms_to_iso(train_info.get("canx_timestamp"))
+    service_date = _date_from_iso(dep_time or canx_time)
+    if not service_date:
+        return None
+
+    return CancellationEvent(
+        train_id=str(train_id),
+        service_date=service_date,
+        stanox=train_info.get("loc_stanox") or None,
+        reason_code=train_info.get("canx_reason_code") or None,
+        cancelled_at_origin=train_info.get("canx_type") == "AT ORIGIN",
+        raw=train_info,
+    )
+
+
+class _FeedListener(stomp.ConnectionListener):
+    """Bridges stomp.py's synchronous callbacks to the feed manager."""
+
+    def __init__(self, manager: NrodFeedManager) -> None:
+        self._manager = manager
+
+    def on_connected(self, frame: Any) -> None:
+        self._manager._on_connected()
+
+    def on_message(self, frame: Any) -> None:
+        self._manager._on_message(frame)
+
+    def on_error(self, frame: Any) -> None:
+        self._manager._on_error(frame)
+
+    def on_disconnected(self) -> None:
+        self._manager._on_disconnected()
+
+
+class NrodFeedManager:
+    """Manages a single shared STOMP connection to the NROD movement feed."""
+
+    def __init__(self, hass: HomeAssistant, username: str, password: str) -> None:
+        """Initialize the feed manager.
+
+        Args:
+            hass: Home Assistant instance
+            username: NROD account username
+            password: NROD account password
+        """
+        self._hass = hass
+        self._username = username
+        self._password = password
+        self._connection: stomp.Connection | None = None
+        self._subscribers: dict[str, list[Callback]] = {}
+        self._entry_stanox: dict[str, set[str]] = {}
+        self._entry_callback: dict[str, Callback] = {}
+        self._reconnect_task: asyncio.Task | None = None
+        self._reconnect_delay: float = NROD_RECONNECT_INITIAL_DELAY
+        self._stopped = True
+
+        self.connected = False
+        self.last_message_at: datetime | None = None
+
+    @property
+    def has_subscribers(self) -> bool:
+        """Return True if any config entry is still using this feed."""
+        return bool(self._entry_callback)
+
+    async def async_acquire(
+        self, entry_id: str, subscriber: Callback, stanox_codes: set[str]
+    ) -> None:
+        """Register a config entry's interest in a set of STANOX codes.
+
+        Establishes the shared STOMP connection if this is the first
+        subscriber overall.
+        """
+        self._entry_callback[entry_id] = subscriber
+        self._entry_stanox[entry_id] = set(stanox_codes)
+        for stanox in stanox_codes:
+            callbacks = self._subscribers.setdefault(stanox, [])
+            if subscriber not in callbacks:
+                callbacks.append(subscriber)
+
+        if self._connection is None:
+            await self._async_connect()
+
+    async def async_release(self, entry_id: str) -> None:
+        """Remove a config entry's subscription.
+
+        Tears down the shared STOMP connection once no entries remain.
+        """
+        subscriber = self._entry_callback.pop(entry_id, None)
+        stanox_codes = self._entry_stanox.pop(entry_id, set())
+
+        for stanox in stanox_codes:
+            callbacks = self._subscribers.get(stanox, [])
+            if subscriber in callbacks:
+                callbacks.remove(subscriber)
+            if not callbacks:
+                self._subscribers.pop(stanox, None)
+
+        if not self.has_subscribers:
+            await self._async_disconnect()
+
+    async def _async_connect(self) -> None:
+        """Establish the shared STOMP connection (off the event loop)."""
+        self._stopped = False
+        await self._hass.async_add_executor_job(self._connect_sync)
+
+    def _connect_sync(self) -> None:
+        """Blocking STOMP connect/subscribe, run in an executor thread."""
+        connection = stomp.Connection(
+            host_and_ports=[(NROD_STOMP_HOST, NROD_STOMP_SSL_PORT)],
+            keepalive=True,
+        )
+        connection.set_ssl(for_hosts=[(NROD_STOMP_HOST, NROD_STOMP_SSL_PORT)])
+        connection.set_listener("nrod", _FeedListener(self))
+        connection.connect(
+            username=self._username,
+            passcode=self._password,
+            wait=True,
+            headers={"client-id": self._username},
+        )
+        connection.subscribe(destination=NROD_STOMP_TOPIC, id="my-rail-commute", ack="auto")
+        self._connection = connection
+
+    async def _async_disconnect(self) -> None:
+        """Tear down the shared STOMP connection."""
+        self._stopped = True
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            self._reconnect_task = None
+
+        connection = self._connection
+        self._connection = None
+        self.connected = False
+
+        if connection is not None:
+            await self._hass.async_add_executor_job(self._disconnect_sync, connection)
+
+    @staticmethod
+    def _disconnect_sync(connection: stomp.Connection) -> None:
+        """Blocking STOMP disconnect, run in an executor thread."""
+        try:
+            connection.disconnect()
+        except Exception:  # noqa: BLE001 - best-effort cleanup of a third-party client
+            _LOGGER.debug("Error disconnecting NROD STOMP connection", exc_info=True)
+
+    # --- callbacks invoked from stomp.py's background thread ---
+
+    def _on_connected(self) -> None:
+        self._hass.loop.call_soon_threadsafe(self._handle_connected)
+
+    def _handle_connected(self) -> None:
+        self.connected = True
+        self._reconnect_delay = NROD_RECONNECT_INITIAL_DELAY
+        _LOGGER.info("Connected to Network Rail Open Data feed")
+
+    def _on_disconnected(self) -> None:
+        self._hass.loop.call_soon_threadsafe(self._handle_disconnected)
+
+    def _handle_disconnected(self) -> None:
+        self.connected = False
+        if self._stopped:
+            return
+        _LOGGER.warning("Disconnected from Network Rail Open Data feed; scheduling reconnect")
+        self._schedule_reconnect()
+
+    def _on_error(self, frame: Any) -> None:
+        _LOGGER.debug("NROD STOMP error frame: %s", getattr(frame, "body", frame))
+
+    def _on_message(self, frame: Any) -> None:
+        body = getattr(frame, "body", frame)
+        self._hass.loop.call_soon_threadsafe(self._handle_frame, body)
+
+    def _handle_frame(self, body: str) -> None:
+        self.last_message_at = dt_util.utcnow()
+        for event in parse_stomp_frame(body):
+            for callback in list(self._subscribers.get(event.stanox, [])):
+                result = callback(event)
+                if asyncio.iscoroutine(result):
+                    self._hass.async_create_task(result)
+
+    def _schedule_reconnect(self) -> None:
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            return
+        self._reconnect_task = self._hass.async_create_background_task(
+            self._async_reconnect_loop(), "nrod_feed_reconnect"
+        )
+
+    async def _async_reconnect_loop(self) -> None:
+        """Retry connecting with exponential backoff until it succeeds or we're stopped."""
+        while not self._stopped and self.has_subscribers and not self.connected:
+            _LOGGER.debug("Reconnecting to NROD feed in %s seconds", self._reconnect_delay)
+            await asyncio.sleep(self._reconnect_delay)
+            if self._stopped or not self.has_subscribers:
+                return
+            try:
+                await self._async_connect()
+                return
+            except Exception:  # noqa: BLE001 - third-party client raises assorted errors
+                _LOGGER.warning("NROD feed reconnect attempt failed", exc_info=True)
+                self._reconnect_delay = min(
+                    self._reconnect_delay * NROD_RECONNECT_BACKOFF_FACTOR,
+                    NROD_RECONNECT_MAX_DELAY,
+                )

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_AVG_DELAY_7D,
@@ -29,7 +30,11 @@ from .const import (
     ATTR_DESTINATION_NAME,
     ATTR_ESTIMATED_ARRIVAL,
     ATTR_EXPECTED_DEPARTURE,
+    ATTR_FEED_CONNECTED,
+    ATTR_FEED_LAST_MESSAGE_AT,
     ATTR_IS_CANCELLED,
+    ATTR_JOURNEYS_RECORDED_TODAY,
+    ATTR_LAST_JOURNEY,
     ATTR_ON_TIME_COUNT,
     ATTR_ON_TIME_COUNT_TODAY,
     ATTR_ON_TIME_PCT_7D,
@@ -39,6 +44,7 @@ from .const import (
     ATTR_ORIGIN,
     ATTR_ORIGIN_NAME,
     ATTR_PLATFORM,
+    ATTR_RECENT_JOURNEYS,
     ATTR_REVERSE_AVG_DELAY_7D,
     ATTR_REVERSE_BEST_DAY,
     ATTR_REVERSE_ON_TIME_PCT_7D,
@@ -100,6 +106,10 @@ async def async_setup_entry(
     # Historical performance sensors
     entities.append(HistoricalReliabilitySensor(coordinator, entry))
     entities.append(HistoricalDelaysSensor(coordinator, entry))
+
+    # Recent Train Times (Network Rail Open Data feed), only when enabled
+    if coordinator.journeys_store is not None:
+        entities.append(RecentTrainTimesSensor(coordinator, entry))
 
     _LOGGER.debug(
         "Setting up %d sensor entities for %s -> %s",
@@ -978,4 +988,64 @@ class HistoricalDelaysSensor(NationalRailCommuteEntity, SensorEntity):
             ATTR_WORST_DAY: best_worst["worst_day"],
             ATTR_BEST_DAY: best_worst["best_day"],
             "days_with_data_7day": rolling_7["days_with_data"],
+        }
+
+
+class RecentTrainTimesSensor(NationalRailCommuteEntity, SensorEntity):
+    """Sensor exposing a log of recent actual train times for this route.
+
+    Backed by the Network Rail Open Data movement feed rather than the
+    Darwin live departure board, so it reflects trains that have already
+    run rather than upcoming ones.
+    """
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = "Recent Train Times"
+        self._attr_unique_id = f"{entry.entry_id}_recent_train_times"
+        self._attr_icon = "mdi:history"
+
+    @staticmethod
+    def _journey_status(journey: dict[str, Any]) -> str:
+        """Return a human-readable status for a journey record."""
+        if journey.get("is_cancelled"):
+            return "Cancelled"
+
+        delay_minutes = journey.get("delay_minutes") or 0
+        if delay_minutes > 0:
+            return f"{delay_minutes} min late"
+
+        return "On Time"
+
+    @property
+    def native_value(self) -> str | None:
+        store = self.coordinator.journeys_store
+        if store is None:
+            return None
+
+        last_journey = store.get_last_journey()
+        if last_journey is None:
+            return "No recent journeys"
+
+        return self._journey_status(last_journey)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        store = self.coordinator.journeys_store
+        if store is None:
+            return {}
+
+        feed_manager = self.coordinator.feed_manager
+        today = dt_util.now().date().isoformat()
+
+        return {
+            ATTR_RECENT_JOURNEYS: store.get_recent_journeys(20),
+            ATTR_LAST_JOURNEY: store.get_last_journey(),
+            ATTR_JOURNEYS_RECORDED_TODAY: store.count_for_date(today),
+            ATTR_FEED_CONNECTED: feed_manager.connected if feed_manager else False,
+            ATTR_FEED_LAST_MESSAGE_AT: feed_manager.last_message_at if feed_manager else None,
         }

--- a/custom_components/my_rail_commute/services.yaml
+++ b/custom_components/my_rail_commute/services.yaml
@@ -122,3 +122,22 @@ get_historical_raw_data:
       required: true
       selector:
         text: {}
+
+get_recent_journeys:
+  name: Get Recent Journeys
+  description: Retrieve the log of recent actual train times (Recent Train Times feature) for a commute, newest first.
+  fields:
+    entry_id:
+      name: Entry ID
+      description: The config entry ID of the commute (find it in Settings → Integrations).
+      required: true
+      selector:
+        text: {}
+    limit:
+      name: Limit
+      description: Maximum number of recent journeys to return (default 20).
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 500

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -28,7 +28,16 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "enable_recent_train_times": "Enable Recent Train Times (requires a Network Rail Open Data account)"
+        }
+      },
+      "nrod_credentials": {
+        "title": "Network Rail Open Data Account",
+        "description": "Recent Train Times uses Network Rail's real-time train movement feed to show actual departure/arrival times. Register for a free account at {signup_url}, then enter your credentials below.\n\nNote: If you already have Recent Train Times enabled on another commute, this step will be skipped automatically.",
+        "data": {
+          "nrod_username": "NROD Username",
+          "nrod_password": "NROD Password"
         }
       },
       "return_journey": {
@@ -45,6 +54,8 @@
       "invalid_station": "Invalid station code. Please use a valid 3-letter CRS code.",
       "same_station": "Origin and destination stations must be different.",
       "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute.",
+      "recent_train_times_needs_destination": "Recent Train Times requires a fixed destination station and cannot be used with 'All Departures'.",
+      "invalid_nrod_auth": "Authentication failed. Please check your Network Rail Open Data username and password.",
       "unknown": "An unexpected error occurred. Please try again."
     },
     "abort": {
@@ -63,12 +74,17 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "enable_recent_train_times": "Enable Recent Train Times (requires a Network Rail Open Data account)",
+          "nrod_username": "NROD Username",
+          "nrod_password": "NROD Password (leave blank to keep the current one)"
         }
       }
     },
     "error": {
-      "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute."
+      "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute.",
+      "recent_train_times_needs_destination": "Recent Train Times requires a fixed destination station and cannot be used with 'All Departures'.",
+      "nrod_credentials_required": "Enabling Recent Train Times requires both a Network Rail Open Data username and password."
     }
   },
   "entity": {

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -28,7 +28,16 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "enable_recent_train_times": "Enable Recent Train Times (requires a Network Rail Open Data account)"
+        }
+      },
+      "nrod_credentials": {
+        "title": "Network Rail Open Data Account",
+        "description": "Recent Train Times uses Network Rail's real-time train movement feed to show actual departure/arrival times. Register for a free account at {signup_url}, then enter your credentials below.\n\nNote: If you already have Recent Train Times enabled on another commute, this step will be skipped automatically.",
+        "data": {
+          "nrod_username": "NROD Username",
+          "nrod_password": "NROD Password"
         }
       },
       "return_journey": {
@@ -45,6 +54,8 @@
       "invalid_station": "Invalid station code. Please use a valid 3-letter CRS code.",
       "same_station": "Origin and destination stations must be different.",
       "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute.",
+      "recent_train_times_needs_destination": "Recent Train Times requires a fixed destination station and cannot be used with 'All Departures'.",
+      "invalid_nrod_auth": "Authentication failed. Please check your Network Rail Open Data username and password.",
       "unknown": "An unexpected error occurred. Please try again."
     },
     "abort": {
@@ -63,12 +74,17 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "enable_recent_train_times": "Enable Recent Train Times (requires a Network Rail Open Data account)",
+          "nrod_username": "NROD Username",
+          "nrod_password": "NROD Password (leave blank to keep the current one)"
         }
       }
     },
     "error": {
-      "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute."
+      "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute.",
+      "recent_train_times_needs_destination": "Recent Train Times requires a fixed destination station and cannot be used with 'All Departures'.",
+      "nrod_credentials_required": "Enabling Recent Train Times requires both a Network Rail Open Data username and password."
     }
   },
   "entity": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "my-rail-commute"
-version = "1.1.5"
+version = "1.2.0"
 description = "Home Assistant custom integration for UK National Rail commutes"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,6 +14,7 @@ aioresponses>=0.7.6
 # Required runtime dependencies
 aiohttp>=3.9.0
 voluptuous>=0.13.1
+stomp.py>=8.1.0,<9
 
 # Home Assistant (for testing)
 homeassistant>=2024.1.0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
+import pytest
 
 from custom_components.my_rail_commute.api import (
     AuthenticationError,
@@ -23,9 +23,12 @@ from custom_components.my_rail_commute.const import (
     CONF_ADD_RETURN_JOURNEY,
     CONF_COMMUTE_NAME,
     CONF_DESTINATION,
+    CONF_ENABLE_RECENT_TRAIN_TIMES,
     CONF_MAJOR_DELAY_THRESHOLD,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
+    CONF_NROD_PASSWORD,
+    CONF_NROD_USERNAME,
     CONF_NUM_SERVICES,
     CONF_ORIGIN,
     CONF_SEVERE_DELAY_THRESHOLD,
@@ -35,6 +38,7 @@ from custom_components.my_rail_commute.const import (
     DEFAULT_SEVERE_DELAY_THRESHOLD,
     DOMAIN,
 )
+from custom_components.my_rail_commute.corpus import CorpusAuthenticationError
 
 
 class TestValidateAPIKey:
@@ -502,6 +506,182 @@ class TestConfigFlow:
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "already_configured"
 
+    async def test_settings_enable_recent_train_times_proceeds_to_nrod_step(
+        self, hass: HomeAssistant
+    ):
+        """Enabling Recent Train Times in settings routes to the NROD credentials step."""
+        result = await self._complete_flow_to_settings(hass, None)
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_COMMUTE_NAME: "Morning Commute",
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+            },
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "nrod_credentials"
+
+    async def test_nrod_credentials_success_creates_entry(self, hass: HomeAssistant):
+        """Valid NROD credentials proceed to return_journey and land in the final entry."""
+        result = await self._complete_flow_to_settings(hass, None)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_COMMUTE_NAME: "Morning Commute",
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+            },
+        )
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_nrod_credentials",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_NROD_USERNAME: "nrod_user", CONF_NROD_PASSWORD: "nrod_pass"},
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "return_journey"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_ENABLE_RECENT_TRAIN_TIMES] is True
+        assert result["data"][CONF_NROD_USERNAME] == "nrod_user"
+        assert result["data"][CONF_NROD_PASSWORD] == "nrod_pass"
+
+    async def test_nrod_credentials_invalid_auth_shows_error(self, hass: HomeAssistant):
+        """A rejected NROD username/password re-shows the form with an error."""
+        result = await self._complete_flow_to_settings(hass, None)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_COMMUTE_NAME: "Morning Commute",
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+            },
+        )
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_nrod_credentials",
+            new=AsyncMock(side_effect=CorpusAuthenticationError("bad creds")),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_NROD_USERNAME: "nrod_user", CONF_NROD_PASSWORD: "wrong"},
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "nrod_credentials"
+        assert result["errors"]["base"] == "invalid_nrod_auth"
+
+    async def test_nrod_credentials_reused_from_existing_entry(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """An existing entry's NROD credentials are reused silently for a new route."""
+        mock_config_entry.add_to_hass(hass)
+        hass.config_entries.async_update_entry(
+            mock_config_entry,
+            data={
+                **mock_config_entry.data,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+                CONF_NROD_USERNAME: "existing_user",
+                CONF_NROD_PASSWORD: "existing_pass",
+            },
+        )
+
+        # Step 1: User (API key) - reused from existing entry
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        # Step 2: Stations - a different destination so it's not a duplicate route
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={"origin_name": "London Paddington", "destination_name": "Oxford"},
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "OXF"},
+            )
+
+        # Step 3: Settings, with Recent Train Times enabled
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_COMMUTE_NAME: "Oxford Commute",
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+            },
+        )
+
+        # NROD credentials step is skipped entirely; straight to return_journey
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "return_journey"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_NROD_USERNAME] == "existing_user"
+        assert result["data"][CONF_NROD_PASSWORD] == "existing_pass"
+
+    async def test_recent_train_times_requires_destination(self, hass: HomeAssistant):
+        """Enabling Recent Train Times with 'All Departures' shows a validation error."""
+        flow = NationalRailCommuteConfigFlow()
+        flow.hass = hass
+        flow._api_key = "valid_key"
+        flow._origin = "PAD"
+        flow._origin_name = "London Paddington"
+        flow._destination = None
+        flow._destination_name = None
+        flow._all_departures = True
+
+        result = await flow.async_step_settings(
+            user_input={
+                CONF_COMMUTE_NAME: "All Departures",
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+            }
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "settings"
+        assert result["errors"]["base"] == "recent_train_times_needs_destination"
+
 
 class TestOptionsFlow:
     """Tests for the options flow."""
@@ -545,6 +725,90 @@ class TestOptionsFlow:
         assert result["data"][CONF_SEVERE_DELAY_THRESHOLD] == 20
         assert result["data"][CONF_MAJOR_DELAY_THRESHOLD] == 12
         assert result["data"][CONF_MINOR_DELAY_THRESHOLD] == 5
+
+    async def test_options_flow_enable_recent_train_times_with_credentials(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Enabling the toggle with credentials supplied saves them into options."""
+        mock_config_entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+                CONF_NROD_USERNAME: "nrod_user",
+                CONF_NROD_PASSWORD: "nrod_pass",
+            },
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_ENABLE_RECENT_TRAIN_TIMES] is True
+        assert result["data"][CONF_NROD_USERNAME] == "nrod_user"
+        assert result["data"][CONF_NROD_PASSWORD] == "nrod_pass"
+
+    async def test_options_flow_enable_recent_train_times_without_credentials_errors(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Enabling the toggle with no credentials on file shows a validation error."""
+        mock_config_entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+            },
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"]["base"] == "nrod_credentials_required"
+
+    async def test_options_flow_blank_password_keeps_existing_credentials(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """A blank password in options means 'keep the existing one'."""
+        mock_config_entry.add_to_hass(hass)
+        hass.config_entries.async_update_entry(
+            mock_config_entry,
+            data={
+                **mock_config_entry.data,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+                CONF_NROD_USERNAME: "existing_user",
+                CONF_NROD_PASSWORD: "existing_pass",
+            },
+        )
+
+        result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_ENABLE_RECENT_TRAIN_TIMES: True,
+                CONF_NROD_USERNAME: "existing_user",
+                CONF_NROD_PASSWORD: "",
+            },
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_NROD_PASSWORD] == "existing_pass"
 
 
 class TestHaversineDistance:

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,169 @@
+"""Tests for the CORPUS reference data store."""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.my_rail_commute.corpus import (
+    CorpusAuthenticationError,
+    CorpusReferenceStore,
+    CorpusUnavailableError,
+)
+
+SAMPLE_CORPUS = {
+    "TIPLOCDATA": [
+        {"STANOX": "87701", "3ALPHA": "PAD", "TIPLOC": "PADTON"},
+        {"STANOX": "87702", "3ALPHA": "PAD", "TIPLOC": "PADTONL"},
+        {"STANOX": "88616", "3ALPHA": "RDG", "TIPLOC": "READING"},
+        {"STANOX": "", "3ALPHA": "", "TIPLOC": ""},
+        {"STANOX": "12345", "3ALPHA": " ", "TIPLOC": "NOCRS"},
+    ]
+}
+
+
+class _FakeResponse:
+    def __init__(self, status: int, json_data=None):
+        self.status = status
+        self._json_data = json_data
+
+    async def json(self, content_type=None):
+        return self._json_data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _make_store(load_return=None):
+    """Return a CorpusReferenceStore with a mocked HA Store and session."""
+    hass = MagicMock()
+    session = MagicMock()
+    with patch("custom_components.my_rail_commute.corpus.Store") as MockStore:
+        instance = MockStore.return_value
+        instance.async_load = AsyncMock(return_value=load_return)
+        instance.async_save = AsyncMock(return_value=None)
+        store = CorpusReferenceStore(hass, session)
+        store._store = instance
+    return store, session
+
+
+@pytest.mark.asyncio
+async def test_async_load_no_cache():
+    """async_load with no persisted data leaves the store empty."""
+    store, _ = _make_store(load_return=None)
+    await store.async_load()
+    assert store.get_stanox_codes_for_crs("PAD") == set()
+
+
+@pytest.mark.asyncio
+async def test_async_load_restores_cache():
+    """async_load restores previously persisted CRS/STANOX mappings."""
+    existing = {
+        "crs_to_stanox": {"PAD": ["87701", "87702"]},
+        "stanox_to_crs": {"87701": "PAD", "87702": "PAD"},
+        "fetched_at": dt_util.utcnow().isoformat(),
+    }
+    store, _ = _make_store(load_return=existing)
+    await store.async_load()
+    assert store.get_stanox_codes_for_crs("PAD") == {"87701", "87702"}
+    assert store.get_crs_for_stanox("87701") == "PAD"
+
+
+def test_parse_corpus_skips_blank_entries():
+    """Blank CRS/STANOX entries are skipped; multi-STANOX CRS codes are merged."""
+    crs_to_stanox, stanox_to_crs = CorpusReferenceStore._parse_corpus(SAMPLE_CORPUS)
+    assert crs_to_stanox["PAD"] == ["87701", "87702"]
+    assert crs_to_stanox["RDG"] == ["88616"]
+    assert "NOCRS" not in stanox_to_crs.values()
+    assert "12345" not in stanox_to_crs
+
+
+@pytest.mark.asyncio
+async def test_async_ensure_fresh_fetches_when_no_cache():
+    """A missing cache triggers a fetch and populates the lookup tables."""
+    store, session = _make_store(load_return=None)
+    await store.async_load()
+    session.get = MagicMock(return_value=_FakeResponse(200, SAMPLE_CORPUS))
+
+    await store.async_ensure_fresh("user", "pass")
+
+    assert store.get_stanox_codes_for_crs("PAD") == {"87701", "87702"}
+    store._store.async_save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_ensure_fresh_skips_when_fresh():
+    """A recently-fetched cache is not refetched."""
+    existing = {
+        "crs_to_stanox": {"PAD": ["87701"]},
+        "stanox_to_crs": {"87701": "PAD"},
+        "fetched_at": dt_util.utcnow().isoformat(),
+    }
+    store, session = _make_store(load_return=existing)
+    await store.async_load()
+    session.get = MagicMock(side_effect=AssertionError("should not fetch when fresh"))
+
+    await store.async_ensure_fresh("user", "pass")
+
+    assert store.get_stanox_codes_for_crs("PAD") == {"87701"}
+
+
+@pytest.mark.asyncio
+async def test_async_ensure_fresh_auth_failure_no_cache_raises():
+    """Auth failure with no existing cache raises CorpusAuthenticationError."""
+    store, session = _make_store(load_return=None)
+    await store.async_load()
+    session.get = MagicMock(return_value=_FakeResponse(401))
+
+    with pytest.raises(CorpusAuthenticationError):
+        await store.async_ensure_fresh("user", "bad_pass")
+
+
+@pytest.mark.asyncio
+async def test_async_ensure_fresh_serves_stale_cache_on_failure():
+    """A fetch failure with an existing stale cache keeps serving the stale data."""
+    stale_fetched_at = (dt_util.utcnow() - timedelta(days=30)).isoformat()
+    existing = {
+        "crs_to_stanox": {"PAD": ["87701"]},
+        "stanox_to_crs": {"87701": "PAD"},
+        "fetched_at": stale_fetched_at,
+    }
+    store, session = _make_store(load_return=existing)
+    await store.async_load()
+    session.get = MagicMock(return_value=_FakeResponse(500))
+
+    await store.async_ensure_fresh("user", "pass")
+
+    # Stale cache is preserved rather than wiped out by the failed refresh
+    assert store.get_stanox_codes_for_crs("PAD") == {"87701"}
+
+
+@pytest.mark.asyncio
+async def test_async_test_credentials_success():
+    """A 200 response means credentials are valid."""
+    store, session = _make_store()
+    session.get = MagicMock(return_value=_FakeResponse(200))
+    await store.async_test_credentials("user", "pass")
+
+
+@pytest.mark.asyncio
+async def test_async_test_credentials_auth_failure():
+    """A 401 response raises CorpusAuthenticationError."""
+    store, session = _make_store()
+    session.get = MagicMock(return_value=_FakeResponse(401))
+    with pytest.raises(CorpusAuthenticationError):
+        await store.async_test_credentials("user", "bad_pass")
+
+
+@pytest.mark.asyncio
+async def test_async_test_credentials_other_failure():
+    """A non-200/401 response raises CorpusUnavailableError."""
+    store, session = _make_store()
+    session.get = MagicMock(return_value=_FakeResponse(503))
+    with pytest.raises(CorpusUnavailableError):
+        await store.async_test_credentials("user", "pass")

--- a/tests/test_journey_correlation.py
+++ b/tests/test_journey_correlation.py
@@ -1,0 +1,250 @@
+"""Tests for the journey correlation engine (the trickiest part of Recent Train Times)."""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.my_rail_commute.const import (
+    JOURNEY_CORRELATION_MAX_MINUTES,
+    JOURNEY_PENDING_TIMEOUT_MINUTES,
+)
+from custom_components.my_rail_commute.journey_store import JourneyCorrelationEngine
+from custom_components.my_rail_commute.nrod_stomp import (
+    EVENT_ARRIVAL,
+    EVENT_DEPARTURE,
+    EVENT_PASS,
+    CancellationEvent,
+    MovementEvent,
+)
+
+ORIGIN_STANOX = "87701"
+DESTINATION_STANOX = "88616"
+
+
+def _departure(train_id="1A23", service_date="2026-07-05", delay=0, platform="9"):
+    return MovementEvent(
+        train_id=train_id,
+        service_date=service_date,
+        stanox=ORIGIN_STANOX,
+        event_type=EVENT_DEPARTURE,
+        planned_time=f"{service_date}T08:00:00+00:00",
+        actual_time=f"{service_date}T08:0{delay}:00+00:00" if delay < 10 else None,
+        platform=platform,
+        toc="GW",
+        variation_status="LATE" if delay else "ON TIME",
+        delay_minutes=delay,
+    )
+
+
+def _arrival(
+    train_id="1A23",
+    service_date="2026-07-05",
+    delay=0,
+    event_type=EVENT_ARRIVAL,
+    stanox=DESTINATION_STANOX,
+):
+    return MovementEvent(
+        train_id=train_id,
+        service_date=service_date,
+        stanox=stanox,
+        event_type=event_type,
+        planned_time=f"{service_date}T08:30:00+00:00",
+        actual_time=f"{service_date}T08:3{delay}:00+00:00" if delay < 10 else None,
+        platform="4",
+        toc="GW",
+        variation_status="LATE" if delay else "ON TIME",
+        delay_minutes=delay,
+    )
+
+
+def _cancellation(train_id="1A23", service_date="2026-07-05", stanox=ORIGIN_STANOX, cancelled_at_origin=True):
+    return CancellationEvent(
+        train_id=train_id,
+        service_date=service_date,
+        stanox=stanox,
+        reason_code="YI",
+        cancelled_at_origin=cancelled_at_origin,
+    )
+
+
+def _make_engine():
+    journeys_store = MagicMock()
+    journeys_store.async_add_journey = AsyncMock()
+    engine = JourneyCorrelationEngine(
+        MagicMock(),
+        "PAD",
+        "RDG",
+        {ORIGIN_STANOX},
+        {DESTINATION_STANOX},
+        journeys_store,
+    )
+    return engine, journeys_store
+
+
+class TestBasicCorrelation:
+    async def test_departure_then_arrival_completes_journey(self):
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure(delay=0))
+        await engine.handle_event(_arrival(delay=4))
+
+        journeys_store.async_add_journey.assert_called_once()
+        record = journeys_store.async_add_journey.call_args[0][0]
+        assert record["train_id"] == "1A23"
+        assert record["is_cancelled"] is False
+        assert record["delay_minutes"] == 4
+        assert record["origin_crs"] == "PAD"
+        assert record["destination_crs"] == "RDG"
+        assert ("1A23", "2026-07-05") not in engine._pending
+
+    async def test_watched_stanox_union(self):
+        engine, _ = _make_engine()
+        assert engine.watched_stanox == {ORIGIN_STANOX, DESTINATION_STANOX}
+
+
+class TestSameHeadcodeDifferentDays:
+    async def test_same_train_id_different_days_not_cross_matched(self):
+        """Headcodes are reused daily; a departure on day 1 must not match day 2's arrival."""
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure(service_date="2026-07-05"))
+        # A different day's arrival for the same headcode must not complete anything
+        await engine.handle_event(_arrival(service_date="2026-07-06"))
+
+        journeys_store.async_add_journey.assert_not_called()
+        # The original day's departure is still pending, waiting for its own arrival
+        assert ("1A23", "2026-07-05") in engine._pending
+
+
+class TestUnmatchedDeparture:
+    async def test_unmatched_departure_times_out_and_is_discarded(self):
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure())
+        key = ("1A23", "2026-07-05")
+        assert key in engine._pending
+
+        # Simulate enough time passing for the pending-timeout sweep to fire
+        engine._pending[key]["recorded_at_dt"] = dt_util.utcnow() - timedelta(
+            minutes=JOURNEY_PENDING_TIMEOUT_MINUTES + 1
+        )
+
+        # Any subsequent event triggers the expiry sweep
+        await engine.handle_event(_departure(train_id="1B99"))
+
+        assert key not in engine._pending
+        journeys_store.async_add_journey.assert_not_called()
+
+    async def test_arrival_beyond_correlation_window_is_not_matched(self):
+        """An arrival for a departure recorded too long ago is not treated as a match."""
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure())
+        key = ("1A23", "2026-07-05")
+        engine._pending[key]["recorded_at_dt"] = dt_util.utcnow() - timedelta(
+            minutes=JOURNEY_CORRELATION_MAX_MINUTES + 1
+        )
+
+        await engine.handle_event(_arrival())
+
+        journeys_store.async_add_journey.assert_not_called()
+        assert key not in engine._pending
+
+
+class TestCancellations:
+    async def test_cancellation_before_departure_is_at_origin(self):
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_cancellation(cancelled_at_origin=True))
+
+        journeys_store.async_add_journey.assert_called_once()
+        record = journeys_store.async_add_journey.call_args[0][0]
+        assert record["is_cancelled"] is True
+        assert record["cancelled_at"] == "origin"
+        assert record["actual_departure"] is None
+
+    async def test_cancellation_en_route_after_departure(self):
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure(delay=0))
+        await engine.handle_event(_cancellation(stanox=DESTINATION_STANOX, cancelled_at_origin=False))
+
+        journeys_store.async_add_journey.assert_called_once()
+        record = journeys_store.async_add_journey.call_args[0][0]
+        assert record["is_cancelled"] is True
+        assert record["cancelled_at"] == "en_route"
+        assert record["actual_departure"] is not None
+        assert ("1A23", "2026-07-05") not in engine._pending
+
+    async def test_cancellation_unrelated_to_route_is_ignored(self):
+        """A cancellation reported at neither origin nor a tracked pending journey is ignored."""
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_cancellation(stanox="99999", cancelled_at_origin=False))
+
+        journeys_store.async_add_journey.assert_not_called()
+
+
+class TestDuplicateAndOutOfOrder:
+    async def test_duplicate_departure_message_is_idempotent(self):
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure())
+        await engine.handle_event(_departure())  # redelivered
+        await engine.handle_event(_arrival())
+
+        journeys_store.async_add_journey.assert_called_once()
+
+    async def test_duplicate_arrival_message_is_idempotent(self):
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure())
+        await engine.handle_event(_arrival())
+        await engine.handle_event(_arrival())  # redelivered
+
+        journeys_store.async_add_journey.assert_called_once()
+
+    async def test_arrival_before_departure_is_dropped_without_crash(self):
+        """Out-of-order delivery (arrival before its departure) is dropped, not an error."""
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_arrival())
+        journeys_store.async_add_journey.assert_not_called()
+
+        # The subsequent (late) departure should still work normally on its own
+        await engine.handle_event(_departure())
+        assert ("1A23", "2026-07-05") in engine._pending
+
+
+class TestThroughStationPassFallback:
+    async def test_pass_completes_journey_when_no_arrival_seen(self):
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure())
+        await engine.handle_event(_arrival(event_type=EVENT_PASS, delay=2))
+
+        journeys_store.async_add_journey.assert_called_once()
+        record = journeys_store.async_add_journey.call_args[0][0]
+        assert record["delay_minutes"] == 2
+
+    async def test_real_arrival_after_pass_is_ignored(self):
+        """Once a PASS has completed the journey, a later ARRIVAL must not re-trigger it."""
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure())
+        await engine.handle_event(_arrival(event_type=EVENT_PASS))
+        await engine.handle_event(_arrival(event_type=EVENT_ARRIVAL))
+
+        journeys_store.async_add_journey.assert_called_once()
+
+    async def test_pass_ignored_once_real_arrival_already_seen(self):
+        """A duplicate PASS after a real ARRIVAL must not produce a second record."""
+        engine, journeys_store = _make_engine()
+
+        await engine.handle_event(_departure())
+        await engine.handle_event(_arrival(event_type=EVENT_ARRIVAL))
+        await engine.handle_event(_arrival(event_type=EVENT_PASS))
+
+        journeys_store.async_add_journey.assert_called_once()

--- a/tests/test_nrod_stomp.py
+++ b/tests/test_nrod_stomp.py
@@ -1,0 +1,320 @@
+"""Tests for the NROD STOMP frame parser and shared feed manager."""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.my_rail_commute.const import (
+    NROD_RECONNECT_BACKOFF_FACTOR,
+    NROD_RECONNECT_INITIAL_DELAY,
+    NROD_RECONNECT_MAX_DELAY,
+)
+from custom_components.my_rail_commute.nrod_stomp import (
+    EVENT_ARRIVAL,
+    EVENT_DEPARTURE,
+    EVENT_PASS,
+    CancellationEvent,
+    MovementEvent,
+    NrodFeedManager,
+    parse_stomp_frame,
+)
+
+
+def _movement_record(
+    msg_type="0003",
+    event_type="DEPARTURE",
+    train_id="1A23",
+    loc_stanox="87701",
+    planned_timestamp="1751702100000",
+    actual_timestamp="1751702160000",
+    timetable_variation="1",
+    variation_status="LATE",
+    platform="9",
+    toc_id="23",
+):
+    return {
+        "header": {"msg_type": msg_type},
+        "body": {
+            "event_type": event_type,
+            "train_id": train_id,
+            "loc_stanox": loc_stanox,
+            "planned_timestamp": planned_timestamp,
+            "actual_timestamp": actual_timestamp,
+            "timetable_variation": timetable_variation,
+            "variation_status": variation_status,
+            "platform": platform,
+            "toc_id": toc_id,
+        },
+    }
+
+
+def _cancellation_record(
+    train_id="1A23",
+    loc_stanox="87701",
+    dep_timestamp="1751702100000",
+    canx_timestamp="1751702000000",
+    canx_reason_code="YI",
+    canx_type="AT ORIGIN",
+):
+    return {
+        "header": {"msg_type": "0002"},
+        "body": {
+            "train_info": {
+                "train_id": train_id,
+                "loc_stanox": loc_stanox,
+                "dep_timestamp": dep_timestamp,
+                "canx_timestamp": canx_timestamp,
+                "canx_reason_code": canx_reason_code,
+                "canx_type": canx_type,
+            }
+        },
+    }
+
+
+class TestParseStompFrame:
+    """Tests for the pure parse_stomp_frame function."""
+
+    def test_parses_departure_movement(self):
+        events = parse_stomp_frame(json.dumps([_movement_record()]))
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, MovementEvent)
+        assert event.event_type == EVENT_DEPARTURE
+        assert event.train_id == "1A23"
+        assert event.stanox == "87701"
+        assert event.delay_minutes == 1
+        assert event.platform == "9"
+        assert event.toc == "23"
+        assert event.service_date  # derived from planned_timestamp
+
+    def test_parses_arrival_movement(self):
+        events = parse_stomp_frame(
+            json.dumps([_movement_record(event_type="ARRIVAL", loc_stanox="88616")])
+        )
+        assert events[0].event_type == EVENT_ARRIVAL
+        assert events[0].stanox == "88616"
+
+    def test_parses_pass_movement(self):
+        events = parse_stomp_frame(json.dumps([_movement_record(event_type="PASS")]))
+        assert events[0].event_type == EVENT_PASS
+
+    def test_early_variation_is_negative_delay(self):
+        events = parse_stomp_frame(
+            json.dumps(
+                [_movement_record(timetable_variation="3", variation_status="EARLY")]
+            )
+        )
+        assert events[0].delay_minutes == -3
+
+    def test_on_time_variation_is_zero_delay(self):
+        events = parse_stomp_frame(
+            json.dumps(
+                [_movement_record(timetable_variation="0", variation_status="ON TIME")]
+            )
+        )
+        assert events[0].delay_minutes == 0
+
+    def test_parses_cancellation(self):
+        events = parse_stomp_frame(json.dumps([_cancellation_record()]))
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, CancellationEvent)
+        assert event.train_id == "1A23"
+        assert event.stanox == "87701"
+        assert event.reason_code == "YI"
+        assert event.cancelled_at_origin is True
+
+    def test_cancellation_not_at_origin(self):
+        events = parse_stomp_frame(
+            json.dumps([_cancellation_record(canx_type="EN ROUTE")])
+        )
+        assert events[0].cancelled_at_origin is False
+
+    def test_unknown_msg_type_ignored(self):
+        record = {"header": {"msg_type": "0001"}, "body": {}}
+        assert parse_stomp_frame(json.dumps([record])) == []
+
+    def test_unknown_event_type_ignored(self):
+        events = parse_stomp_frame(json.dumps([_movement_record(event_type="REINSTATEMENT")]))
+        assert events == []
+
+    def test_missing_required_fields_ignored(self):
+        record = _movement_record()
+        del record["body"]["train_id"]
+        assert parse_stomp_frame(json.dumps([record])) == []
+
+    def test_malformed_json_returns_empty(self):
+        assert parse_stomp_frame("not json") == []
+
+    def test_non_list_json_returns_empty(self):
+        assert parse_stomp_frame(json.dumps({"not": "a list"})) == []
+
+    def test_non_dict_record_is_skipped(self):
+        events = parse_stomp_frame(json.dumps(["not a dict", _movement_record()]))
+        assert len(events) == 1
+        assert events[0].train_id == "1A23"
+
+    def test_mixed_valid_and_invalid_records(self):
+        records = [
+            _movement_record(train_id="1A23"),
+            {"header": {"msg_type": "9999"}, "body": {}},
+            _cancellation_record(train_id="1B45"),
+        ]
+        events = parse_stomp_frame(json.dumps(records))
+        assert len(events) == 2
+        assert events[0].train_id == "1A23"
+        assert events[1].train_id == "1B45"
+
+
+def _make_hass():
+    """Return a hass mock whose executor/loop hooks run callables inline."""
+    hass = MagicMock()
+    hass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda fn, *a: fn(*a))
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    hass.async_create_task = MagicMock(side_effect=lambda coro: asyncio.ensure_future(coro))
+    hass.async_create_background_task = MagicMock(
+        side_effect=lambda coro, name: asyncio.ensure_future(coro)
+    )
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_acquire_connects_only_once_for_multiple_entries():
+    """A second entry acquiring the feed must not open a second connection."""
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+    manager._connect_sync = MagicMock(side_effect=lambda: setattr(manager, "_connection", MagicMock()))
+
+    callback_a = MagicMock()
+    callback_b = MagicMock()
+
+    await manager.async_acquire("entry_a", callback_a, {"87701"})
+    await manager.async_acquire("entry_b", callback_b, {"88616"})
+
+    manager._connect_sync.assert_called_once()
+    assert manager.has_subscribers
+
+
+@pytest.mark.asyncio
+async def test_release_keeps_connection_while_other_entry_remains():
+    """Releasing one of two entries must not tear down the shared connection."""
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+    manager._connect_sync = MagicMock(side_effect=lambda: setattr(manager, "_connection", MagicMock()))
+    manager._disconnect_sync = MagicMock()
+
+    await manager.async_acquire("entry_a", MagicMock(), {"87701"})
+    await manager.async_acquire("entry_b", MagicMock(), {"88616"})
+
+    await manager.async_release("entry_a")
+
+    manager._disconnect_sync.assert_not_called()
+    assert manager.has_subscribers
+
+
+@pytest.mark.asyncio
+async def test_release_last_entry_disconnects():
+    """Releasing the last entry tears down the shared connection."""
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+    manager._connect_sync = MagicMock(side_effect=lambda: setattr(manager, "_connection", MagicMock()))
+    manager._disconnect_sync = MagicMock()
+
+    await manager.async_acquire("entry_a", MagicMock(), {"87701"})
+    await manager.async_release("entry_a")
+
+    manager._disconnect_sync.assert_called_once()
+    assert not manager.has_subscribers
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_by_stanox_only_to_matching_subscriber():
+    """An incoming event is only delivered to the subscriber for its STANOX."""
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+    manager._connect_sync = MagicMock()
+
+    callback_a = MagicMock()
+    callback_b = MagicMock()
+    await manager.async_acquire("entry_a", callback_a, {"87701"})
+    await manager.async_acquire("entry_b", callback_b, {"88616"})
+
+    frame_body = json.dumps([_movement_record(loc_stanox="87701")])
+    manager._on_message(MagicMock(body=frame_body))
+
+    callback_a.assert_called_once()
+    callback_b.assert_not_called()
+    assert manager.last_message_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reconnect_loop_backs_off_and_resets_on_success():
+    """Reconnect attempts back off exponentially and reset the delay once connected."""
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+
+    attempts = {"count": 0}
+
+    async def _fake_connect():
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise ConnectionError("simulated failure")
+        manager._on_connected()  # simulates the real STOMP connect callback
+
+    manager._async_connect = _fake_connect
+    manager._entry_callback["entry_a"] = MagicMock()  # has_subscribers -> True
+    manager._stopped = False
+
+    sleep_calls = []
+
+    async def _fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    with patch(
+        "custom_components.my_rail_commute.nrod_stomp.asyncio.sleep",
+        side_effect=_fake_sleep,
+    ):
+        await manager._async_reconnect_loop()
+
+    assert attempts["count"] == 3
+    assert sleep_calls == [
+        NROD_RECONNECT_INITIAL_DELAY,
+        NROD_RECONNECT_INITIAL_DELAY * NROD_RECONNECT_BACKOFF_FACTOR,
+        NROD_RECONNECT_INITIAL_DELAY * NROD_RECONNECT_BACKOFF_FACTOR**2,
+    ]
+    # A successful connect resets the backoff delay for next time
+    assert manager._reconnect_delay == NROD_RECONNECT_INITIAL_DELAY
+    assert manager.connected is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_delay_caps_at_max():
+    """The reconnect delay never exceeds NROD_RECONNECT_MAX_DELAY."""
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+    manager._reconnect_delay = NROD_RECONNECT_MAX_DELAY / (NROD_RECONNECT_BACKOFF_FACTOR - 0.5)
+
+    async def _always_fail():
+        raise ConnectionError("simulated failure")
+
+    manager._async_connect = _always_fail
+    manager._entry_callback["entry_a"] = MagicMock()
+    manager._stopped = False
+
+    call_count = {"n": 0}
+
+    async def _fake_sleep(delay):
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            manager._stopped = True  # stop the loop after a couple of iterations
+
+    with patch(
+        "custom_components.my_rail_commute.nrod_stomp.asyncio.sleep",
+        side_effect=_fake_sleep,
+    ):
+        await manager._async_reconnect_loop()
+
+    assert manager._reconnect_delay <= NROD_RECONNECT_MAX_DELAY

--- a/tests/test_recent_journeys_store.py
+++ b/tests/test_recent_journeys_store.py
@@ -1,0 +1,118 @@
+"""Tests for the RecentJourneysStore persistence log."""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.my_rail_commute.const import (
+    RECENT_JOURNEYS_MAX_STORED,
+    RECENT_JOURNEYS_RETENTION_DAYS,
+)
+from custom_components.my_rail_commute.journey_store import RecentJourneysStore
+
+
+def _make_store(load_return=None):
+    """Return a RecentJourneysStore with a mocked HA Store."""
+    hass = MagicMock()
+    with patch("custom_components.my_rail_commute.journey_store.Store") as MockStore:
+        instance = MockStore.return_value
+        instance.async_load = AsyncMock(return_value=load_return)
+        instance.async_save = AsyncMock(return_value=None)
+        store = RecentJourneysStore(hass, "test_entry_id")
+        store._store = instance
+    return store
+
+
+def _journey(train_id="1A23", service_date="2026-07-05", recorded_at="2026-07-05T08:35:00+00:00"):
+    return {
+        "train_id": train_id,
+        "service_date": service_date,
+        "recorded_at": recorded_at,
+        "is_cancelled": False,
+        "delay_minutes": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_load_no_data():
+    store = _make_store(load_return=None)
+    await store.async_load()
+    assert store.get_recent_journeys() == []
+    assert store.get_last_journey() is None
+
+
+@pytest.mark.asyncio
+async def test_add_journey_persists_and_returns_newest_first():
+    store = _make_store(load_return=None)
+    await store.async_load()
+
+    await store.async_add_journey(_journey(train_id="1A01", recorded_at="2026-07-05T08:00:00+00:00"))
+    await store.async_add_journey(_journey(train_id="1A02", recorded_at="2026-07-05T09:00:00+00:00"))
+
+    recent = store.get_recent_journeys()
+    assert [j["train_id"] for j in recent] == ["1A02", "1A01"]
+    assert store.get_last_journey()["train_id"] == "1A02"
+    store._store.async_save.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_get_recent_journeys_respects_limit():
+    store = _make_store(load_return=None)
+    await store.async_load()
+
+    for i in range(5):
+        await store.async_add_journey(
+            _journey(train_id=f"1A{i:02d}", recorded_at=f"2026-07-05T0{i}:00:00+00:00")
+        )
+
+    limited = store.get_recent_journeys(limit=2)
+    assert [j["train_id"] for j in limited] == ["1A04", "1A03"]
+
+
+@pytest.mark.asyncio
+async def test_count_for_date():
+    store = _make_store(load_return=None)
+    await store.async_load()
+
+    await store.async_add_journey(_journey(service_date="2026-07-05"))
+    await store.async_add_journey(_journey(train_id="1B45", service_date="2026-07-05"))
+    await store.async_add_journey(_journey(train_id="1C67", service_date="2026-07-04"))
+
+    assert store.count_for_date("2026-07-05") == 2
+    assert store.count_for_date("2026-07-04") == 1
+    assert store.count_for_date("2026-07-06") == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_removes_entries_beyond_retention_window():
+    today = dt_util.now().date()
+    stale_date = (today - timedelta(days=RECENT_JOURNEYS_RETENTION_DAYS + 5)).isoformat()
+    fresh_date = today.isoformat()
+
+    existing = {
+        "journeys": [
+            _journey(train_id="OLD", service_date=stale_date, recorded_at=f"{stale_date}T08:00:00+00:00"),
+            _journey(train_id="NEW", service_date=fresh_date, recorded_at=f"{fresh_date}T08:00:00+00:00"),
+        ]
+    }
+    store = _make_store(load_return=existing)
+    await store.async_load()
+
+    remaining = store.get_recent_journeys(limit=10)
+    assert [j["train_id"] for j in remaining] == ["NEW"]
+
+
+@pytest.mark.asyncio
+async def test_prune_caps_total_stored_count():
+    store = _make_store(load_return=None)
+    await store.async_load()
+
+    for i in range(RECENT_JOURNEYS_MAX_STORED + 10):
+        await store.async_add_journey(
+            _journey(train_id=f"T{i}", recorded_at=f"2026-07-05T00:00:{i % 60:02d}+00:00")
+        )
+
+    assert len(store.get_recent_journeys(limit=RECENT_JOURNEYS_MAX_STORED + 50)) == RECENT_JOURNEYS_MAX_STORED

--- a/tests/test_sensor_recent_train_times.py
+++ b/tests/test_sensor_recent_train_times.py
@@ -1,0 +1,136 @@
+"""Tests for RecentTrainTimesSensor and NrodFeedConnectedBinarySensor."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.my_rail_commute.binary_sensor import (
+    NrodFeedConnectedBinarySensor,
+)
+from custom_components.my_rail_commute.const import (
+    ATTR_FEED_CONNECTED,
+    ATTR_FEED_LAST_MESSAGE_AT,
+    ATTR_JOURNEYS_RECORDED_TODAY,
+    ATTR_LAST_JOURNEY,
+    ATTR_RECENT_JOURNEYS,
+)
+from custom_components.my_rail_commute.coordinator import (
+    NationalRailDataUpdateCoordinator,
+)
+from custom_components.my_rail_commute.sensor import RecentTrainTimesSensor
+
+
+def _make_coordinator(journeys_store=None, feed_manager=None):
+    coordinator = MagicMock(spec=NationalRailDataUpdateCoordinator)
+    coordinator.origin = "PAD"
+    coordinator.destination = "RDG"
+    coordinator.journeys_store = journeys_store
+    coordinator.feed_manager = feed_manager
+    return coordinator
+
+
+def _make_entry():
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"commute_name": "Test Commute"}
+    return entry
+
+
+class TestRecentTrainTimesSensor:
+    def test_native_value_none_when_feature_disabled(self):
+        coordinator = _make_coordinator(journeys_store=None)
+        sensor = RecentTrainTimesSensor(coordinator, _make_entry())
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes == {}
+
+    def test_native_value_no_recent_journeys(self):
+        store = MagicMock()
+        store.get_last_journey.return_value = None
+        coordinator = _make_coordinator(journeys_store=store)
+        sensor = RecentTrainTimesSensor(coordinator, _make_entry())
+        assert sensor.native_value == "No recent journeys"
+
+    def test_native_value_on_time(self):
+        store = MagicMock()
+        store.get_last_journey.return_value = {"is_cancelled": False, "delay_minutes": 0}
+        coordinator = _make_coordinator(journeys_store=store)
+        sensor = RecentTrainTimesSensor(coordinator, _make_entry())
+        assert sensor.native_value == "On Time"
+
+    def test_native_value_delayed(self):
+        store = MagicMock()
+        store.get_last_journey.return_value = {"is_cancelled": False, "delay_minutes": 7}
+        coordinator = _make_coordinator(journeys_store=store)
+        sensor = RecentTrainTimesSensor(coordinator, _make_entry())
+        assert sensor.native_value == "7 min late"
+
+    def test_native_value_cancelled(self):
+        store = MagicMock()
+        store.get_last_journey.return_value = {"is_cancelled": True, "delay_minutes": None}
+        coordinator = _make_coordinator(journeys_store=store)
+        sensor = RecentTrainTimesSensor(coordinator, _make_entry())
+        assert sensor.native_value == "Cancelled"
+
+    def test_extra_state_attributes(self):
+        store = MagicMock()
+        journeys = [{"train_id": "1A23"}]
+        store.get_recent_journeys.return_value = journeys
+        store.get_last_journey.return_value = journeys[0]
+        store.count_for_date.return_value = 3
+
+        feed_manager = MagicMock()
+        feed_manager.connected = True
+        feed_manager.last_message_at = "2026-07-05T08:00:00+00:00"
+
+        coordinator = _make_coordinator(journeys_store=store, feed_manager=feed_manager)
+        sensor = RecentTrainTimesSensor(coordinator, _make_entry())
+
+        attrs = sensor.extra_state_attributes
+        assert attrs[ATTR_RECENT_JOURNEYS] == journeys
+        assert attrs[ATTR_LAST_JOURNEY] == journeys[0]
+        assert attrs[ATTR_JOURNEYS_RECORDED_TODAY] == 3
+        assert attrs[ATTR_FEED_CONNECTED] is True
+        assert attrs[ATTR_FEED_LAST_MESSAGE_AT] == "2026-07-05T08:00:00+00:00"
+
+    def test_extra_state_attributes_no_feed_manager(self):
+        """Feed connectivity attrs degrade gracefully if the feed never started."""
+        store = MagicMock()
+        store.get_recent_journeys.return_value = []
+        store.get_last_journey.return_value = None
+        store.count_for_date.return_value = 0
+
+        coordinator = _make_coordinator(journeys_store=store, feed_manager=None)
+        sensor = RecentTrainTimesSensor(coordinator, _make_entry())
+
+        attrs = sensor.extra_state_attributes
+        assert attrs[ATTR_FEED_CONNECTED] is False
+        assert attrs[ATTR_FEED_LAST_MESSAGE_AT] is None
+
+
+class TestNrodFeedConnectedBinarySensor:
+    def test_is_on_reflects_feed_connected(self):
+        feed_manager = MagicMock()
+        feed_manager.connected = True
+        coordinator = _make_coordinator(feed_manager=feed_manager)
+        sensor = NrodFeedConnectedBinarySensor(coordinator, _make_entry())
+        assert sensor.is_on is True
+
+    def test_is_on_false_when_disconnected(self):
+        feed_manager = MagicMock()
+        feed_manager.connected = False
+        coordinator = _make_coordinator(feed_manager=feed_manager)
+        sensor = NrodFeedConnectedBinarySensor(coordinator, _make_entry())
+        assert sensor.is_on is False
+
+    def test_is_on_false_when_no_feed_manager(self):
+        coordinator = _make_coordinator(feed_manager=None)
+        sensor = NrodFeedConnectedBinarySensor(coordinator, _make_entry())
+        assert sensor.is_on is False
+
+    def test_extra_state_attributes(self):
+        feed_manager = MagicMock()
+        feed_manager.last_message_at = "2026-07-05T08:00:00+00:00"
+        coordinator = _make_coordinator(feed_manager=feed_manager)
+        sensor = NrodFeedConnectedBinarySensor(coordinator, _make_entry())
+        assert sensor.extra_state_attributes[ATTR_FEED_LAST_MESSAGE_AT] == (
+            "2026-07-05T08:00:00+00:00"
+        )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.exceptions import ServiceValidationError
 import pytest
 
 from custom_components.my_rail_commute import (
     SERVICE_GET_HISTORICAL_RAW_DATA,
+    SERVICE_GET_RECENT_JOURNEYS,
     async_setup_entry,
-    async_unload_entry,
 )
 from custom_components.my_rail_commute.const import DOMAIN
 
@@ -44,11 +45,10 @@ async def test_get_historical_raw_data_returns_days():
     hass, coordinator, stats_store = _make_hass(raw_data=raw_data)
 
     # Simulate calling the handler directly via the registered service
-    registered_handler = None
+    registered_handlers: dict = {}
 
     def capture_register(domain, service_name, handler, **kwargs):
-        nonlocal registered_handler
-        registered_handler = handler
+        registered_handlers[service_name] = handler
 
     hass.services.has_service = MagicMock(return_value=False)
     hass.services.async_register = MagicMock(side_effect=capture_register)
@@ -70,6 +70,7 @@ async def test_get_historical_raw_data_returns_days():
     ):
         mock_coord_instance = MagicMock()
         mock_coord_instance.stats_store = stats_store
+        mock_coord_instance.journeys_store = None
         mock_coord_instance.async_config_entry_first_refresh = AsyncMock()
         MockCoord.return_value = mock_coord_instance
 
@@ -84,9 +85,9 @@ async def test_get_historical_raw_data_returns_days():
 
         await async_setup_entry(hass, entry)
 
-    assert registered_handler is not None
+    assert SERVICE_GET_HISTORICAL_RAW_DATA in registered_handlers
     call = _FakeServiceCall("test_entry_id")
-    result = await registered_handler(call)
+    result = await registered_handlers[SERVICE_GET_HISTORICAL_RAW_DATA](call)
     assert "days" in result
     assert result["days"] == raw_data
 
@@ -98,11 +99,10 @@ async def test_get_historical_raw_data_invalid_entry_id():
 
     hass, _, _ = _make_hass(entry_id="real_entry")
 
-    registered_handler = None
+    registered_handlers: dict = {}
 
     def capture_register(domain, service_name, handler, **kwargs):
-        nonlocal registered_handler
-        registered_handler = handler
+        registered_handlers[service_name] = handler
 
     hass.services.has_service = MagicMock(return_value=False)
     hass.services.async_register = MagicMock(side_effect=capture_register)
@@ -122,6 +122,7 @@ async def test_get_historical_raw_data_invalid_entry_id():
         patch("custom_components.my_rail_commute.CommuteStatisticsStore") as MockStore,
     ):
         mock_coord_instance = MagicMock()
+        mock_coord_instance.journeys_store = None
         mock_coord_instance.async_config_entry_first_refresh = AsyncMock()
         MockCoord.return_value = mock_coord_instance
 
@@ -135,7 +136,106 @@ async def test_get_historical_raw_data_invalid_entry_id():
 
         await async_setup_entry(hass, entry)
 
-    assert registered_handler is not None
+    assert SERVICE_GET_HISTORICAL_RAW_DATA in registered_handlers
     call = _FakeServiceCall("nonexistent_entry_id")
     with pytest.raises(ServiceValidationError):
-        await registered_handler(call)
+        await registered_handlers[SERVICE_GET_HISTORICAL_RAW_DATA](call)
+
+
+@pytest.mark.asyncio
+async def test_get_recent_journeys_returns_journeys():
+    """Service handler returns recent journeys for an entry with the feature enabled."""
+    journeys = [{"train_id": "1A23", "service_date": "2026-07-05", "is_cancelled": False}]
+    hass, _, _ = _make_hass(entry_id="test_entry_id")
+
+    registered_handlers: dict = {}
+
+    def capture_register(domain, service_name, handler, **kwargs):
+        registered_handlers[service_name] = handler
+
+    hass.services.has_service = MagicMock(return_value=False)
+    hass.services.async_register = MagicMock(side_effect=capture_register)
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.data = {"api_key": "test_key", "origin": "PAD", "destination": "RDG",
+                  "time_window": 60, "num_services": 3, "night_updates": False,
+                  "severe_delay_threshold": 15, "major_delay_threshold": 10,
+                  "minor_delay_threshold": 3, "departed_train_grace_period": 5}
+    entry.options = {}
+
+    with (
+        patch("custom_components.my_rail_commute.async_get_clientsession"),
+        patch("custom_components.my_rail_commute.NationalRailAPI"),
+        patch("custom_components.my_rail_commute.NationalRailDataUpdateCoordinator") as MockCoord,
+        patch("custom_components.my_rail_commute.CommuteStatisticsStore") as MockStore,
+    ):
+        mock_coord_instance = MagicMock()
+        mock_coord_instance.async_config_entry_first_refresh = AsyncMock()
+        mock_coord_instance.journeys_store.get_recent_journeys = MagicMock(return_value=journeys)
+        MockCoord.return_value = mock_coord_instance
+
+        mock_store_instance = MagicMock()
+        mock_store_instance.async_load = AsyncMock()
+        MockStore.return_value = mock_store_instance
+
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        hass.data = {}
+
+        await async_setup_entry(hass, entry)
+
+    assert SERVICE_GET_RECENT_JOURNEYS in registered_handlers
+    call = _FakeServiceCall("test_entry_id")
+    call.data["limit"] = 10
+    result = await registered_handlers[SERVICE_GET_RECENT_JOURNEYS](call)
+    assert result == {"journeys": journeys}
+    mock_coord_instance.journeys_store.get_recent_journeys.assert_called_once_with(10)
+
+
+@pytest.mark.asyncio
+async def test_get_recent_journeys_not_enabled_raises():
+    """Service handler raises ServiceValidationError when the feature isn't enabled."""
+    hass, _, _ = _make_hass(entry_id="test_entry_id")
+
+    registered_handlers: dict = {}
+
+    def capture_register(domain, service_name, handler, **kwargs):
+        registered_handlers[service_name] = handler
+
+    hass.services.has_service = MagicMock(return_value=False)
+    hass.services.async_register = MagicMock(side_effect=capture_register)
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.data = {"api_key": "test_key", "origin": "PAD", "destination": "RDG",
+                  "time_window": 60, "num_services": 3, "night_updates": False,
+                  "severe_delay_threshold": 15, "major_delay_threshold": 10,
+                  "minor_delay_threshold": 3, "departed_train_grace_period": 5}
+    entry.options = {}
+
+    with (
+        patch("custom_components.my_rail_commute.async_get_clientsession"),
+        patch("custom_components.my_rail_commute.NationalRailAPI"),
+        patch("custom_components.my_rail_commute.NationalRailDataUpdateCoordinator") as MockCoord,
+        patch("custom_components.my_rail_commute.CommuteStatisticsStore") as MockStore,
+    ):
+        mock_coord_instance = MagicMock()
+        mock_coord_instance.journeys_store = None
+        mock_coord_instance.async_config_entry_first_refresh = AsyncMock()
+        MockCoord.return_value = mock_coord_instance
+
+        mock_store_instance = MagicMock()
+        mock_store_instance.async_load = AsyncMock()
+        MockStore.return_value = mock_store_instance
+
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        hass.data = {}
+
+        await async_setup_entry(hass, entry)
+
+    assert SERVICE_GET_RECENT_JOURNEYS in registered_handlers
+    call = _FakeServiceCall("test_entry_id")
+    with pytest.raises(ServiceValidationError):
+        await registered_handlers[SERVICE_GET_RECENT_JOURNEYS](call)


### PR DESCRIPTION
Adds an opt-in per-route log of actual train movements (arrival/departure
times, delay, platform, cancellations) sourced from Network Rail's
real-time TRAIN_MVT_ALL_TOC feed over STOMP, since the existing Darwin
API only ever exposes live/forecast data and never confirms actual times.

- corpus.py: fetches/caches Network Rail's CORPUS reference data to
  resolve CRS codes to STANOX codes used by the movement feed
- nrod_stomp.py: shared, ref-counted STOMP feed connection (Network Rail
  disallows multiple simultaneous connections per account), bridging
  stomp.py's thread/callback client into HA's asyncio loop
- journey_store.py: correlates origin-departure and destination-arrival
  events into journey records (keyed by train_id + service_date to avoid
  cross-day headcode reuse) and persists a rolling log per commute
- New opt-in config flow step for NROD credentials (reused across routes
  like the existing API key), new RecentTrainTimesSensor and a feed
  connectivity diagnostic binary sensor, and a get_recent_journeys action

Feed/CORPUS failures degrade gracefully and never affect the existing
Darwin-based sensors.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013jarTkehE25Ys9t3kpbw75