### PR TITLE
Bound NROD STOMP connect with a timeout to stop bootstrap hangs

### DIFF
--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -178,6 +178,15 @@ NROD_CORPUS_URL: Final = (
     "https://publicdatafeeds.networkrail.co.uk/ntrod/SupportingFileAuthenticate?type=CORPUS"
 )
 
+# Bounds the STOMP socket connect (stomp.py's own socket timeout, which
+# defaults to None/blocking) so an unreachable or silently-dropping NROD
+# endpoint can never hang forever.
+NROD_CONNECT_SOCKET_TIMEOUT: Final = 15  # seconds
+# Bounds the overall connect+handshake executor job. Kept above the socket
+# timeout to leave room for the post-connect STOMP handshake wait, which
+# stomp.py performs with no timeout of its own.
+NROD_CONNECT_TIMEOUT: Final = 30  # seconds
+
 NROD_RECONNECT_INITIAL_DELAY: Final = 5  # seconds
 NROD_RECONNECT_MAX_DELAY: Final = 300  # seconds
 NROD_RECONNECT_BACKOFF_FACTOR: Final = 2

--- a/custom_components/my_rail_commute/nrod_stomp.py
+++ b/custom_components/my_rail_commute/nrod_stomp.py
@@ -21,6 +21,8 @@ from homeassistant.util import dt as dt_util
 import stomp
 
 from .const import (
+    NROD_CONNECT_SOCKET_TIMEOUT,
+    NROD_CONNECT_TIMEOUT,
     NROD_RECONNECT_BACKOFF_FACTOR,
     NROD_RECONNECT_INITIAL_DELAY,
     NROD_RECONNECT_MAX_DELAY,
@@ -288,15 +290,32 @@ class NrodFeedManager:
             await self._async_disconnect()
 
     async def _async_connect(self) -> None:
-        """Establish the shared STOMP connection (off the event loop)."""
+        """Establish the shared STOMP connection (off the event loop).
+
+        Bounded by NROD_CONNECT_TIMEOUT so an unreachable or slow-to-respond
+        NROD endpoint can never block Home Assistant's bootstrap. A timeout
+        is raised like any other connect failure, so callers (including the
+        reconnect backoff loop) handle it the same way.
+        """
         self._stopped = False
-        await self._hass.async_add_executor_job(self._connect_sync)
+        try:
+            await asyncio.wait_for(
+                self._hass.async_add_executor_job(self._connect_sync),
+                timeout=NROD_CONNECT_TIMEOUT,
+            )
+        except asyncio.TimeoutError as err:
+            _LOGGER.warning(
+                "Timed out connecting to Network Rail Open Data feed after %s seconds",
+                NROD_CONNECT_TIMEOUT,
+            )
+            raise ConnectionError("Timed out connecting to NROD feed") from err
 
     def _connect_sync(self) -> None:
         """Blocking STOMP connect/subscribe, run in an executor thread."""
         connection = stomp.Connection(
             host_and_ports=[(NROD_STOMP_HOST, NROD_STOMP_SSL_PORT)],
             keepalive=True,
+            timeout=NROD_CONNECT_SOCKET_TIMEOUT,
         )
         connection.set_ssl(for_hosts=[(NROD_STOMP_HOST, NROD_STOMP_SSL_PORT)])
         connection.set_listener("nrod", _FeedListener(self))


### PR DESCRIPTION
stomp.py's Connection defaults to no socket timeout and its connect(wait=True)
handshake wait has no timeout of its own, so an unreachable or silently
dropping NROD endpoint left the executor job awaited in async_setup_entry
blocked forever, stalling Home Assistant's stage 2 bootstrap until it force-
cancelled the task. Add a socket-level timeout to the stomp.py Connection
and wrap the connect executor job in asyncio.wait_for so a stuck connection
raises like any other connect failure instead of hanging the caller.