### PR TITLE
Serialize NROD connects and disown stale attempts to stop connection collisions

### DIFF
--- a/custom_components/my_rail_commute/nrod_stomp.py
+++ b/custom_components/my_rail_commute/nrod_stomp.py
@@ -244,6 +244,8 @@ class NrodFeedManager:
         self._reconnect_task: asyncio.Task | None = None
         self._reconnect_delay: float = NROD_RECONNECT_INITIAL_DELAY
         self._stopped = True
+        self._connect_lock = asyncio.Lock()
+        self._connect_generation = 0
 
         self.connected = False
         self.last_message_at: datetime | None = None
@@ -259,7 +261,11 @@ class NrodFeedManager:
         """Register a config entry's interest in a set of STANOX codes.
 
         Establishes the shared STOMP connection if this is the first
-        subscriber overall.
+        subscriber overall. Serialized by _connect_lock so that config
+        entries set up concurrently during HA bootstrap can't each race
+        into opening their own connection — NROD only allows a single
+        connection per account, so two simultaneous logins just knock
+        each other off the feed.
         """
         self._entry_callback[entry_id] = subscriber
         self._entry_stanox[entry_id] = set(stanox_codes)
@@ -268,8 +274,9 @@ class NrodFeedManager:
             if subscriber not in callbacks:
                 callbacks.append(subscriber)
 
-        if self._connection is None:
-            await self._async_connect()
+        async with self._connect_lock:
+            if self._connection is None:
+                await self._async_connect()
 
     async def async_release(self, entry_id: str) -> None:
         """Remove a config entry's subscription.
@@ -296,11 +303,22 @@ class NrodFeedManager:
         NROD endpoint can never block Home Assistant's bootstrap. A timeout
         is raised like any other connect failure, so callers (including the
         reconnect backoff loop) handle it the same way.
+
+        Cancelling the asyncio.wait_for on timeout does not stop the blocking
+        call running in the executor thread — Python threads can't be forced
+        to stop. That leftover thread can still finish the STOMP login after
+        we've already given up, and since NROD allows only one connection per
+        account, a stray late login is enough to knock a subsequent, genuine
+        attempt off the feed. _connect_generation lets an abandoned attempt
+        recognise itself when it finally finishes and disconnect instead of
+        being treated as live.
         """
         self._stopped = False
+        self._connect_generation += 1
+        generation = self._connect_generation
         try:
             await asyncio.wait_for(
-                self._hass.async_add_executor_job(self._connect_sync),
+                self._hass.async_add_executor_job(self._connect_sync, generation),
                 timeout=NROD_CONNECT_TIMEOUT,
             )
         except asyncio.TimeoutError as err:
@@ -310,7 +328,7 @@ class NrodFeedManager:
             )
             raise ConnectionError("Timed out connecting to NROD feed") from err
 
-    def _connect_sync(self) -> None:
+    def _connect_sync(self, generation: int) -> None:
         """Blocking STOMP connect/subscribe, run in an executor thread."""
         connection = stomp.Connection(
             host_and_ports=[(NROD_STOMP_HOST, NROD_STOMP_SSL_PORT)],
@@ -326,11 +344,24 @@ class NrodFeedManager:
             headers={"client-id": self._username},
         )
         connection.subscribe(destination=NROD_STOMP_TOPIC, id="my-rail-commute", ack="auto")
+
+        if generation != self._connect_generation:
+            _LOGGER.warning(
+                "NROD login completed after the caller had already given up on it; "
+                "disconnecting the stray session instead of leaving it open"
+            )
+            try:
+                connection.disconnect()
+            except Exception:  # noqa: BLE001 - best-effort cleanup of a third-party client
+                _LOGGER.debug("Error disconnecting abandoned NROD connection", exc_info=True)
+            return
+
         self._connection = connection
 
     async def _async_disconnect(self) -> None:
         """Tear down the shared STOMP connection."""
         self._stopped = True
+        self._connect_generation += 1
         if self._reconnect_task is not None:
             self._reconnect_task.cancel()
             self._reconnect_task = None
@@ -400,7 +431,10 @@ class NrodFeedManager:
             if self._stopped or not self.has_subscribers:
                 return
             try:
-                await self._async_connect()
+                async with self._connect_lock:
+                    if self.connected:
+                        return
+                    await self._async_connect()
                 return
             except Exception:  # noqa: BLE001 - third-party client raises assorted errors
                 _LOGGER.warning("NROD feed reconnect attempt failed", exc_info=True)

--- a/tests/test_nrod_stomp.py
+++ b/tests/test_nrod_stomp.py
@@ -186,7 +186,9 @@ async def test_acquire_connects_only_once_for_multiple_entries():
     """A second entry acquiring the feed must not open a second connection."""
     hass = _make_hass()
     manager = NrodFeedManager(hass, "user", "pass")
-    manager._connect_sync = MagicMock(side_effect=lambda: setattr(manager, "_connection", MagicMock()))
+    manager._connect_sync = MagicMock(
+        side_effect=lambda generation: setattr(manager, "_connection", MagicMock())
+    )
 
     callback_a = MagicMock()
     callback_b = MagicMock()
@@ -203,7 +205,9 @@ async def test_release_keeps_connection_while_other_entry_remains():
     """Releasing one of two entries must not tear down the shared connection."""
     hass = _make_hass()
     manager = NrodFeedManager(hass, "user", "pass")
-    manager._connect_sync = MagicMock(side_effect=lambda: setattr(manager, "_connection", MagicMock()))
+    manager._connect_sync = MagicMock(
+        side_effect=lambda generation: setattr(manager, "_connection", MagicMock())
+    )
     manager._disconnect_sync = MagicMock()
 
     await manager.async_acquire("entry_a", MagicMock(), {"87701"})
@@ -220,7 +224,9 @@ async def test_release_last_entry_disconnects():
     """Releasing the last entry tears down the shared connection."""
     hass = _make_hass()
     manager = NrodFeedManager(hass, "user", "pass")
-    manager._connect_sync = MagicMock(side_effect=lambda: setattr(manager, "_connection", MagicMock()))
+    manager._connect_sync = MagicMock(
+        side_effect=lambda generation: setattr(manager, "_connection", MagicMock())
+    )
     manager._disconnect_sync = MagicMock()
 
     await manager.async_acquire("entry_a", MagicMock(), {"87701"})
@@ -248,6 +254,30 @@ async def test_dispatch_routes_by_stanox_only_to_matching_subscriber():
     callback_a.assert_called_once()
     callback_b.assert_not_called()
     assert manager.last_message_at is not None
+
+
+def test_connect_sync_disconnects_stale_attempt():
+    """A connect that finishes after the caller gave up must tear itself down.
+
+    asyncio.wait_for can't stop the blocking connect running in the executor
+    thread, so a timed-out attempt keeps running in the background. If it
+    later succeeds, it must not be adopted as the live connection (NROD only
+    allows one login per account, so a stray leftover session would knock a
+    subsequent, genuine connection off the feed).
+    """
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+
+    stale_connection = MagicMock()
+    with patch(
+        "custom_components.my_rail_commute.nrod_stomp.stomp.Connection",
+        return_value=stale_connection,
+    ):
+        manager._connect_generation = 2  # a newer attempt has since started
+        manager._connect_sync(1)  # this attempt was generation 1 - now stale
+
+    stale_connection.disconnect.assert_called_once()
+    assert manager._connection is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The previous timeout fix stopped a stuck NROD connect from hanging HA's
bootstrap forever, but two gaps remained that reproduce the same
"could not connect to host ... port 61618" / ConnectionError symptoms
even when the feed is reachable:

- async_acquire had no locking, so config entries set up concurrently
  during bootstrap could each see self._connection is None and race
  into opening their own STOMP login. NROD only allows one connection
  per account, so simultaneous logins knock each other off the feed.
  Serialize connect attempts behind an asyncio.Lock shared by
  async_acquire and the reconnect loop.

- Cancelling asyncio.wait_for on timeout doesn't stop the blocking
  connect running in the executor thread (Python threads can't be
  force-stopped), so a timed-out attempt can finish its STOMP login
  later, after the caller already gave up. That stray session then
  blocks the next real reconnect attempt. Track a connect generation
  so a late-finishing attempt recognises it's been abandoned and
  disconnects instead of being adopted as the live connection.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018tsmALgwQt6WCPQBK18PnS