### PR TITLE
Retry NROD feed connection instead of failing setup permanently

### DIFF
--- a/custom_components/my_rail_commute/nrod_stomp.py
+++ b/custom_components/my_rail_commute/nrod_stomp.py
@@ -266,6 +266,13 @@ class NrodFeedManager:
         into opening their own connection — NROD only allows a single
         connection per account, so two simultaneous logins just knock
         each other off the feed.
+
+        A failed initial connect does not raise: it falls back to the same
+        backoff reconnect loop used for post-connect drops, so a transient
+        NROD outage during HA bootstrap doesn't permanently strand this
+        entry's subscription (unlogged and unregistered from the shared
+        manager, since it registers itself above before ever attempting to
+        connect).
         """
         self._entry_callback[entry_id] = subscriber
         self._entry_stanox[entry_id] = set(stanox_codes)
@@ -275,8 +282,16 @@ class NrodFeedManager:
                 callbacks.append(subscriber)
 
         async with self._connect_lock:
-            if self._connection is None:
-                await self._async_connect()
+            if self._connection is None and not self.connected:
+                try:
+                    await self._async_connect()
+                except Exception:  # noqa: BLE001 - third-party client raises assorted errors
+                    _LOGGER.warning(
+                        "Initial connect to Network Rail Open Data feed failed; "
+                        "scheduling reconnect",
+                        exc_info=True,
+                    )
+                    self._schedule_reconnect()
 
     async def async_release(self, entry_id: str) -> None:
         """Remove a config entry's subscription.

--- a/tests/test_nrod_stomp.py
+++ b/tests/test_nrod_stomp.py
@@ -237,6 +237,31 @@ async def test_release_last_entry_disconnects():
 
 
 @pytest.mark.asyncio
+async def test_acquire_survives_initial_connect_failure():
+    """A failed initial connect must not raise out of async_acquire.
+
+    Previously this exception propagated to the caller, which meant the
+    config entry's coordinator never got wired to the feed manager and no
+    reconnect was ever scheduled - Recent Train Times stayed permanently
+    broken for that entry until Home Assistant was restarted.
+    """
+    hass = _make_hass()
+    manager = NrodFeedManager(hass, "user", "pass")
+    manager._connect_sync = MagicMock(side_effect=ConnectionError("simulated failure"))
+
+    # Must not raise, even though the connect attempt fails.
+    await manager.async_acquire("entry_a", MagicMock(), {"87701"})
+
+    assert manager.has_subscribers
+    assert manager._reconnect_task is not None
+
+    manager._stopped = True  # let the background reconnect loop exit cleanly
+    manager._reconnect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await manager._reconnect_task
+
+
+@pytest.mark.asyncio
 async def test_dispatch_routes_by_stanox_only_to_matching_subscriber():
     """An incoming event is only delivered to the subscriber for its STANOX."""
     hass = _make_hass()


### PR DESCRIPTION
A failed initial STOMP connect during async_acquire raised out to
__init__.py, which logged and swallowed it - but that meant the
config entry's coordinator never got wired to the feed manager, so
async_release was never called on unload and no reconnect was ever
scheduled. A transient NROD outage during HA bootstrap left Recent
Train Times permanently broken for that entry until a full restart.

Route initial connect failures into the existing backoff reconnect
loop instead, matching how post-connect drops are already handled.