### PR TITLE
Enable stomp.py verbose logging to diagnose NROD connect failures

### DIFF
--- a/custom_components/my_rail_commute/nrod_stomp.py
+++ b/custom_components/my_rail_commute/nrod_stomp.py
@@ -19,6 +19,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 import stomp
+import stomp.logging as stomp_logging
 
 from .const import (
     NROD_CONNECT_SOCKET_TIMEOUT,
@@ -32,6 +33,14 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# stomp.py swallows the real connect-failure reason (DNS failure, refused
+# connection, TLS handshake error, timeout) inside its own retry loop and
+# raises a bare, message-less ConnectFailedException with no exception
+# chaining. Its internal warning log line does carry the real exception, but
+# only attaches it (exc_info) when this flag is set - so without it, "could
+# not connect to host ..." is logged with the traceback stripped.
+stomp_logging.verbose = True
 
 EVENT_ARRIVAL = "ARRIVAL"
 EVENT_DEPARTURE = "DEPARTURE"

--- a/tests/test_nrod_stomp.py
+++ b/tests/test_nrod_stomp.py
@@ -169,6 +169,15 @@ class TestParseStompFrame:
         assert events[1].train_id == "1B45"
 
 
+def test_stomp_verbose_logging_enabled():
+    """stomp.py's internal exc_info logging must stay on so the real
+    connect-failure reason (not just a bare ConnectFailedException) reaches
+    the HA log the next time a connect attempt fails."""
+    import stomp.logging as stomp_logging
+
+    assert stomp_logging.verbose is True
+
+
 def _make_hass():
     """Return a hass mock whose executor/loop hooks run callables inline."""
     hass = MagicMock()


### PR DESCRIPTION
ConnectFailedException is raised bare with no message and no exception
chaining, so the real cause (DNS failure, refused connection, TLS
handshake error, timeout, etc.) never reaches the HA log. stomp.py's own
internal warning line does capture that exception, but only attaches it
when its verbose flag is set, which nothing in this codebase did.