### PR TITLE
feat(config_flow,coordinator,sensor): support multi-leg journeys with changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,23 @@ To track multiple routes:
 2. Configure different origin/destination pairs for each
 3. Each commute will appear as a separate device with its own sensors
 
+### Multi-Leg Journeys
+
+Many commutes require a change of train partway through (e.g. Home → Interchange, then a different service Interchange → Work). To set one up:
+
+1. During setup, configure your first leg (origin → destination) as usual
+2. When asked "Add a connecting leg?", choose yes and enter the next destination — the new leg's origin is automatically the station you just alighted at
+3. Repeat for as many changes as your journey needs, then decline to finish the itinerary
+4. Continue through the settings step as normal (time window, number of services tracked, and delay thresholds apply to every leg)
+
+A multi-leg journey creates one device with sensors per leg instead of the flat train list:
+- `sensor.{commute_name}_leg{n}_summary`, `_status`, `_next_train`, and `_train_{m}` for each leg `n`
+- The top-level `Summary`/`Status` sensors (and the `Has Disruption` binary sensor) reflect the **whole journey**: worst-case status across all legs, and combined service counts
+
+**Note**: Historical Reliability/Delays sensors report on-time percentage and average delay for the **combined whole journey**, not broken down by individual leg.
+
+If you also enable "Add return journey" for a multi-leg journey, the return route reverses the entire leg sequence (e.g. Home→Interchange→Work becomes Work→Interchange→Home), not just the overall origin/destination.
+
 ## Update Intervals
 
 The integration automatically adjusts update frequency based on time of day:

--- a/custom_components/my_rail_commute/__init__.py
+++ b/custom_components/my_rail_commute/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
@@ -155,24 +156,24 @@ async def async_cleanup_stale_entities(hass: HomeAssistant, entry: ConfigEntry) 
     # Get entity registry
     entity_reg = er.async_get(hass)
 
+    # Matches both the single-leg shape ({entry_id}_train_{n}) and the
+    # multi-leg shape ({entry_id}_leg{leg}_train_{n})
+    leg_train_re = re.compile(rf"^{re.escape(entry.entry_id)}_(?:leg\d+_)?train_(\d+)$")
+
     # Find all train entities for this config entry
     entities_to_remove = []
     for entity in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
         # Check if this is a train entity with a number > new_num_services
-        if entity.unique_id.startswith(f"{entry.entry_id}_train_"):
-            # Extract train number from unique_id (format: {entry_id}_train_{number})
-            try:
-                train_number = int(entity.unique_id.split("_train_")[-1])
-                if train_number > new_num_services:
-                    entities_to_remove.append((entity.entity_id, train_number))
-                    _LOGGER.debug(
-                        "Found stale train entity: %s (train_%s)",
-                        entity.entity_id,
-                        train_number,
-                    )
-            except (ValueError, IndexError):
-                # Skip if we can't parse the train number
-                continue
+        match = leg_train_re.match(entity.unique_id)
+        if match:
+            train_number = int(match.group(1))
+            if train_number > new_num_services:
+                entities_to_remove.append((entity.entity_id, train_number))
+                _LOGGER.debug(
+                    "Found stale train entity: %s (train_%s)",
+                    entity.entity_id,
+                    train_number,
+                )
 
     # Remove stale entities
     for entity_id, train_number in entities_to_remove:

--- a/custom_components/my_rail_commute/binary_sensor.py
+++ b/custom_components/my_rail_commute/binary_sensor.py
@@ -19,7 +19,7 @@ from .const import (
     CONF_COMMUTE_NAME,
     DOMAIN,
 )
-from .coordinator import NationalRailDataUpdateCoordinator
+from .coordinator import NationalRailDataUpdateCoordinator, build_route_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,12 +75,7 @@ class NationalRailCommuteBinarySensor(
 
         # Create device info
         commute_name = entry.data.get(CONF_COMMUTE_NAME, "My Rail Commute")
-        origin = coordinator.origin
-        destination = coordinator.destination
-
-        device_id = (
-            f"{origin}_{destination}" if destination else f"{origin}_all_departures"
-        )
+        device_id = build_route_id(coordinator.legs)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
             name=commute_name,

--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -22,6 +22,7 @@ from .api import (
     NationalRailAPIError,
 )
 from .const import (
+    CONF_ADD_LEG,
     CONF_ADD_RETURN_JOURNEY,
     CONF_ALL_DEPARTURES,
     CONF_COMMUTE_NAME,
@@ -29,6 +30,8 @@ from .const import (
     CONF_DESTINATION,
     CONF_DISRUPTION_MULTIPLE_DELAY,
     CONF_DISRUPTION_SINGLE_DELAY,
+    CONF_LEG_DESTINATION,
+    CONF_LEGS,
     CONF_MAJOR_DELAY_THRESHOLD,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
@@ -56,6 +59,7 @@ from .const import (
     MIN_NUM_SERVICES,
     MIN_TIME_WINDOW,
 )
+from .coordinator import build_route_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -194,6 +198,8 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._minor_delay_threshold: int | None = None
         self._departed_train_grace_period: int | None = None
         self._nearby_stations: list[tuple[float, dict]] | None = None
+        self._legs: list[dict[str, Any]] = []
+        self._leg_names: list[dict[str, str]] = []
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -321,6 +327,10 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._origin_name = origin_name
                     self._destination_name = None
                     self._all_departures = True
+                    self._legs = [{"origin": self._origin, "destination": None}]
+                    self._leg_names = [
+                        {"origin_name": self._origin_name, "destination_name": None}
+                    ]
                 else:
                     destination = user_input.get(CONF_DESTINATION, "").strip()
                     if not destination:
@@ -337,8 +347,18 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._origin_name = station_info["origin_name"]
                     self._destination_name = station_info["destination_name"]
                     self._all_departures = False
+                    self._legs = [{"origin": self._origin, "destination": self._destination}]
+                    self._leg_names = [
+                        {
+                            "origin_name": self._origin_name,
+                            "destination_name": self._destination_name,
+                        }
+                    ]
 
-                return await self.async_step_settings()
+                if self._all_departures:
+                    return await self.async_step_settings()
+
+                return await self.async_step_add_leg()
 
             except ValueError as err:
                 if "destination_required" not in str(err):
@@ -386,6 +406,85 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_add_leg(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Offer to add a connecting leg (a change of train) to the journey.
+
+        Loops until the user declines: each accepted leg's origin is the
+        previous leg's destination (where you alight and change trains).
+
+        Args:
+            user_input: User input data
+
+        Returns:
+            FlowResult for the next add_leg prompt or the settings step
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            if not user_input.get(CONF_ADD_LEG, False):
+                return await self.async_step_settings()
+
+            try:
+                new_destination = user_input.get(CONF_LEG_DESTINATION, "").strip()
+                if not new_destination:
+                    errors[CONF_LEG_DESTINATION] = "required"
+                    raise ValueError("destination_required")
+
+                station_info = await validate_stations(
+                    self.hass, self._api_key, self._destination, new_destination
+                )
+
+                new_destination = new_destination.upper()
+                self._legs.append(
+                    {"origin": self._destination, "destination": new_destination}
+                )
+                self._leg_names.append(
+                    {
+                        "origin_name": station_info["origin_name"],
+                        "destination_name": station_info["destination_name"],
+                    }
+                )
+                self._destination = new_destination
+                self._destination_name = station_info["destination_name"]
+
+                # Loop back to offer another leg
+                return await self.async_step_add_leg()
+
+            except ValueError as err:
+                if "destination_required" not in str(err):
+                    errors["base"] = "same_station"
+            except InvalidStationError:
+                errors["base"] = "invalid_station"
+            except AuthenticationError:
+                errors["base"] = "invalid_auth"
+            except NationalRailAPIError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        itinerary = " → ".join(
+            [self._leg_names[0]["origin_name"]]
+            + [n["destination_name"] for n in self._leg_names]
+        )
+
+        return self.async_show_form(
+            step_id="add_leg",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_ADD_LEG, default=False): selector.BooleanSelector(),
+                    vol.Optional(CONF_LEG_DESTINATION): str,
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "itinerary": itinerary,
+                "destination": self._destination_name,
+            },
+        )
+
     async def async_step_settings(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -428,12 +527,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD
                 )
 
-                # Set unique ID based on route (all-departures gets a distinct suffix)
-                if self._all_departures:
-                    unique_id = f"{self._origin}_all_departures"
-                else:
-                    unique_id = f"{self._origin}_{self._destination}"
-                await self.async_set_unique_id(unique_id)
+                # Set unique ID based on the full route chain (all-departures
+                # gets a distinct suffix; single-leg routes match the historical format)
+                await self.async_set_unique_id(build_route_id(self._legs))
                 self._abort_if_unique_id_configured()
 
                 # Skip return-journey step when showing all departures
@@ -553,7 +649,13 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Returns:
             FlowResult for creating entry
         """
-        reverse_unique_id = f"{self._destination}_{self._origin}"
+        # Reverse the whole leg sequence: swap origin/destination within each
+        # leg and reverse leg order (e.g. A->B->C becomes C->B->A)
+        reversed_legs = [
+            {"origin": leg["destination"], "destination": leg["origin"]}
+            for leg in reversed(self._legs)
+        ]
+        reverse_unique_id = build_route_id(reversed_legs)
         reverse_exists = any(
             entry.unique_id == reverse_unique_id
             for entry in self._async_current_entries()
@@ -564,23 +666,27 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if user_input.get(CONF_ADD_RETURN_JOURNEY, False):
+                reverse_data: dict[str, Any] = {
+                    CONF_API_KEY: self._api_key,
+                    CONF_ORIGIN: self._destination,
+                    CONF_DESTINATION: self._origin,
+                    CONF_COMMUTE_NAME: f"{self._destination_name} to {self._origin_name}",
+                    CONF_TIME_WINDOW: self._time_window,
+                    CONF_NUM_SERVICES: self._num_services,
+                    CONF_NIGHT_UPDATES: self._night_updates,
+                    CONF_SEVERE_DELAY_THRESHOLD: self._severe_delay_threshold,
+                    CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
+                    CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
+                    CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
+                }
+                if len(self._legs) > 1:
+                    reverse_data[CONF_LEGS] = reversed_legs
+
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_init(
                         DOMAIN,
                         context={"source": config_entries.SOURCE_IMPORT},
-                        data={
-                            CONF_API_KEY: self._api_key,
-                            CONF_ORIGIN: self._destination,
-                            CONF_DESTINATION: self._origin,
-                            CONF_COMMUTE_NAME: f"{self._destination_name} to {self._origin_name}",
-                            CONF_TIME_WINDOW: self._time_window,
-                            CONF_NUM_SERVICES: self._num_services,
-                            CONF_NIGHT_UPDATES: self._night_updates,
-                            CONF_SEVERE_DELAY_THRESHOLD: self._severe_delay_threshold,
-                            CONF_MAJOR_DELAY_THRESHOLD: self._major_delay_threshold,
-                            CONF_MINOR_DELAY_THRESHOLD: self._minor_delay_threshold,
-                            CONF_DEPARTED_TRAIN_GRACE_PERIOD: self._departed_train_grace_period,
-                        },
+                        data=reverse_data,
                     )
                 )
             return self._create_entry()
@@ -612,9 +718,10 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Returns:
             FlowResult creating the entry, or aborting if already configured
         """
-        await self.async_set_unique_id(
-            f"{user_input[CONF_ORIGIN]}_{user_input[CONF_DESTINATION]}"
-        )
+        legs = user_input.get(CONF_LEGS) or [
+            {"origin": user_input[CONF_ORIGIN], "destination": user_input.get(CONF_DESTINATION)}
+        ]
+        await self.async_set_unique_id(build_route_id(legs))
         self._abort_if_unique_id_configured()
         return self.async_create_entry(
             title=user_input[CONF_COMMUTE_NAME],
@@ -638,6 +745,10 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
         if self._destination:
             data[CONF_DESTINATION] = self._destination
+        if len(self._legs) > 1:
+            data[CONF_LEGS] = self._legs
+            data[CONF_ORIGIN] = self._legs[0]["origin"]
+            data[CONF_DESTINATION] = self._legs[-1]["destination"]
         return self.async_create_entry(title=self._commute_name, data=data)
 
     @staticmethod

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -19,6 +19,9 @@ CONF_MINOR_DELAY_THRESHOLD: Final = "minor_delay_threshold"
 CONF_DEPARTED_TRAIN_GRACE_PERIOD: Final = "departed_train_grace_period"
 CONF_ADD_RETURN_JOURNEY: Final = "add_return_journey"
 CONF_ALL_DEPARTURES: Final = "all_departures"
+CONF_LEGS: Final = "legs"
+CONF_ADD_LEG: Final = "add_leg"
+CONF_LEG_DESTINATION: Final = "leg_destination"
 
 # Legacy config keys (for migration)
 CONF_DISRUPTION_SINGLE_DELAY: Final = "disruption_single_delay"
@@ -123,6 +126,8 @@ ATTR_DISRUPTION_TYPE: Final = "disruption_type"
 ATTR_AFFECTED_SERVICES: Final = "affected_services"
 ATTR_MAX_DELAY: Final = "max_delay_minutes"
 ATTR_DISRUPTION_REASONS: Final = "disruption_reasons"
+ATTR_LEGS: Final = "legs"
+ATTR_IS_MULTI_LEG: Final = "is_multi_leg"
 
 # API Error Messages
 ERROR_AUTH: Final = "Authentication failed. Please check your API key."

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -1,4 +1,5 @@
 """Data update coordinator for My Rail Commute integration."""
+
 from __future__ import annotations
 
 import asyncio
@@ -18,6 +19,7 @@ from .const import (
     CONF_DESTINATION,
     CONF_DISRUPTION_MULTIPLE_DELAY,
     CONF_DISRUPTION_SINGLE_DELAY,
+    CONF_LEGS,
     CONF_MAJOR_DELAY_THRESHOLD,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
@@ -50,6 +52,34 @@ _LOGGER = logging.getLogger(__name__)
 
 _TIME_FORMAT_RE = re.compile(r"^\d{2}:\d{2}$")
 
+# Severity ranking used to combine per-leg statuses into one overall status
+_STATUS_ORDER: list[str] = [
+    STATUS_NORMAL,
+    STATUS_MINOR_DELAYS,
+    STATUS_MAJOR_DELAYS,
+    STATUS_SEVERE_DISRUPTION,
+    STATUS_CRITICAL,
+]
+
+
+def build_route_id(legs: list[dict[str, Any]]) -> str:
+    """Build a stable, chain-based route identifier from a list of legs.
+
+    For a single leg with a destination this is byte-identical to the
+    historical `f"{origin}_{destination}"` format. Every intermediate
+    station is embedded in the id, so different multi-leg chains that
+    happen to share the same overall origin/destination never collide.
+
+    Args:
+        legs: List of {"origin": crs, "destination": crs|None} dicts
+
+    Returns:
+        Route identifier string
+    """
+    if len(legs) == 1 and legs[0]["destination"] is None:
+        return f"{legs[0]['origin']}_all_departures"
+    return "_".join([legs[0]["origin"]] + [leg["destination"] for leg in legs])
+
 
 class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Rail data."""
@@ -77,11 +107,21 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         self.origin = config[CONF_ORIGIN]
         self.destination = config.get(CONF_DESTINATION)  # None when all_departures=True
         self.all_departures = config.get(CONF_ALL_DEPARTURES, False)
+
+        # Journey legs: a list of {"origin": crs, "destination": crs|None} dicts.
+        # Falls back to a single leg built from origin/destination when CONF_LEGS
+        # is absent (all existing single-leg entries), so behaviour is unchanged.
+        self.legs: list[dict[str, Any]] = config.get(CONF_LEGS) or [
+            {"origin": self.origin, "destination": self.destination}
+        ]
+        self.is_multi_leg = len(self.legs) > 1
         self.time_window = int(config[CONF_TIME_WINDOW])
         self.num_services = int(config[CONF_NUM_SERVICES])
         self.night_updates_enabled = config.get(CONF_NIGHT_UPDATES, False)
         self.departed_train_grace_period = int(
-            config.get(CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD)
+            config.get(
+                CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD
+            )
         )
 
         # Delay thresholds (user-configurable)
@@ -99,7 +139,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 config.get(CONF_DISRUPTION_SINGLE_DELAY, DEFAULT_SEVERE_DELAY_THRESHOLD)
             )
             self.major_delay_threshold = int(
-                config.get(CONF_DISRUPTION_MULTIPLE_DELAY, DEFAULT_MAJOR_DELAY_THRESHOLD)
+                config.get(
+                    CONF_DISRUPTION_MULTIPLE_DELAY, DEFAULT_MAJOR_DELAY_THRESHOLD
+                )
             )
             self.minor_delay_threshold = DEFAULT_MINOR_DELAY_THRESHOLD
 
@@ -155,7 +197,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             if not self.night_updates_enabled:
                 # Use a moderate interval so coordinator can reschedule when morning comes
                 # This ensures manual refresh works and automatic updates resume at dawn
-                _LOGGER.debug("Using longer interval during night time (manual refresh still works)")
+                _LOGGER.debug(
+                    "Using longer interval during night time (manual refresh still works)"
+                )
                 return timedelta(hours=1)
             return UPDATE_INTERVAL_NIGHT
 
@@ -187,7 +231,11 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         async with self._update_interval_lock:
             new_interval = self._get_update_interval()
             if new_interval != self.update_interval:
-                _LOGGER.debug("Updating interval from %s to %s", self.update_interval, new_interval)
+                _LOGGER.debug(
+                    "Updating interval from %s to %s",
+                    self.update_interval,
+                    new_interval,
+                )
                 self.update_interval = new_interval
 
         try:
@@ -197,23 +245,48 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 self.destination or "ALL",
             )
 
-            # When showing all departures, fetch enough rows to populate multiple destinations
-            num_rows = max(self.num_services, 20) if self.all_departures else self.num_services
+            if self.is_multi_leg:
+                # Fetch each leg sequentially (not concurrently) so the shared
+                # API client's rate limiter can throttle correctly between calls
+                raw_leg_data: list[dict[str, Any]] = []
+                for leg in self.legs:
+                    raw_leg_data.append(
+                        await self.api.get_departure_board(
+                            leg["origin"],
+                            destination_crs=leg["destination"],
+                            time_window=self.time_window,
+                            num_rows=self.num_services,
+                        )
+                    )
 
-            # Fetch departure board
-            data = await self.api.get_departure_board(
-                self.origin,
-                destination_crs=self.destination,
-                time_window=self.time_window,
-                num_rows=num_rows,
-            )
+                self.origin_name = raw_leg_data[0].get("location_name", self.origin)
+                self.destination_name = raw_leg_data[-1].get(
+                    "destination_name", self.destination
+                )
 
-            # Store station names
-            self.origin_name = data.get("location_name", self.origin)
-            self.destination_name = data.get("destination_name", self.destination)
+                parsed_data = self._parse_data(raw_leg_data)
+            else:
+                # When showing all departures, fetch enough rows to populate multiple destinations
+                num_rows = (
+                    max(self.num_services, 20)
+                    if self.all_departures
+                    else self.num_services
+                )
 
-            # Parse and enrich data
-            parsed_data = self._parse_data(data)
+                # Fetch departure board
+                data = await self.api.get_departure_board(
+                    self.origin,
+                    destination_crs=self.destination,
+                    time_window=self.time_window,
+                    num_rows=num_rows,
+                )
+
+                # Store station names
+                self.origin_name = data.get("location_name", self.origin)
+                self.destination_name = data.get("destination_name", self.destination)
+
+                # Parse and enrich data
+                parsed_data = self._parse_data(data)
 
             # Record observation in historical stats store
             if self.stats_store is not None:
@@ -232,8 +305,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         except NationalRailAPIError as err:
             self._failed_updates += 1
-            _LOGGER.error("Error fetching data: %s (attempt %s/%s)",
-                         err, self._failed_updates, self._max_failed_updates)
+            _LOGGER.error(
+                "Error fetching data: %s (attempt %s/%s)",
+                err,
+                self._failed_updates,
+                self._max_failed_updates,
+            )
 
             # If we've failed too many times, raise UpdateFailed
             if self._failed_updates >= self._max_failed_updates:
@@ -248,29 +325,35 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                         if age > timedelta(hours=2):
                             _LOGGER.warning(
                                 "Cached data is too old (%s hours), not returning stale data",
-                                age.total_seconds() / 3600
+                                age.total_seconds() / 3600,
                             )
-                            raise UpdateFailed(f"Failed to fetch data and cached data too old: {err}") from err
+                            raise UpdateFailed(
+                                f"Failed to fetch data and cached data too old: {err}"
+                            ) from err
                     else:
                         _LOGGER.error(
                             "Failed to parse last_updated timestamp '%s', cannot verify data age",
-                            self.data.get("last_updated")
+                            self.data.get("last_updated"),
                         )
                 except (ValueError, TypeError) as parse_err:
                     _LOGGER.error(
                         "Error parsing last_updated timestamp '%s': %s - cannot verify data age",
                         self.data.get("last_updated"),
-                        parse_err
+                        parse_err,
                     )
 
             # Otherwise, return last known data if available and recent
             if self.data:
-                _LOGGER.warning("Using last known data after failed update (data age: unverified)")
+                _LOGGER.warning(
+                    "Using last known data after failed update (data age: unverified)"
+                )
                 return self.data
 
             raise UpdateFailed(f"Failed to fetch data: {err}") from err
 
-    def _filter_departed_trains(self, services: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _filter_departed_trains(
+        self, services: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """Filter out trains that have already departed.
 
         Args:
@@ -305,8 +388,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
             try:
                 # Parse current time and departure time using a reference date
-                current_dt = datetime.strptime(f"2000-01-01 {current_time_str}", "%Y-%m-%d %H:%M")
-                departure_dt = datetime.strptime(f"2000-01-01 {departure_time}", "%Y-%m-%d %H:%M")
+                current_dt = datetime.strptime(
+                    f"2000-01-01 {current_time_str}", "%Y-%m-%d %H:%M"
+                )
+                departure_dt = datetime.strptime(
+                    f"2000-01-01 {departure_time}", "%Y-%m-%d %H:%M"
+                )
 
                 # Calculate time difference
                 time_diff_seconds = (departure_dt - current_dt).total_seconds()
@@ -342,7 +429,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         return filtered_services
 
-    def _build_services_by_destination(self, services: list[dict[str, Any]]) -> dict[str, Any]:
+    def _build_services_by_destination(
+        self, services: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """Group services by their destination and compute per-destination status.
 
         Args:
@@ -374,16 +463,19 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         return groups
 
-    def _parse_data(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Parse and enrich API data.
+    def _parse_leg_data(
+        self, leg: dict[str, Any], raw_data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Parse and enrich a single leg's raw API data.
 
         Args:
-            data: Raw API data
+            leg: The leg's {"origin", "destination"} config
+            raw_data: Raw departure board data for this leg
 
         Returns:
-            Parsed data with additional calculated fields
+            Parsed per-leg data with additional calculated fields
         """
-        services = data.get("services", [])
+        services = raw_data.get("services", [])
 
         # Limit to configured number of services
         services = services[: self.num_services]
@@ -392,12 +484,8 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         services = self._filter_departed_trains(services)
 
         # Calculate statistics
-        on_time_count = sum(
-            1 for s in services if s.get("status") == STATUS_ON_TIME
-        )
-        delayed_count = sum(
-            1 for s in services if s.get("status") == STATUS_DELAYED
-        )
+        on_time_count = sum(1 for s in services if s.get("status") == STATUS_ON_TIME)
+        delayed_count = sum(1 for s in services if s.get("status") == STATUS_DELAYED)
         cancelled_count = sum(
             1 for s in services if s.get("status") == STATUS_CANCELLED
         )
@@ -410,7 +498,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Build summary
         if self.all_departures:
-            summary = self._build_all_departures_summary(len(services), on_time_count, delayed_count, cancelled_count)
+            summary = self._build_all_departures_summary(
+                len(services), on_time_count, delayed_count, cancelled_count
+            )
         else:
             summary = self._build_summary(on_time_count, delayed_count, cancelled_count)
 
@@ -421,14 +511,13 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 next_train = service
                 break
 
-        result: dict[str, Any] = {
-            "origin": self.origin,
-            "origin_name": self.origin_name or self.origin,
-            "destination": self.destination,
-            "destination_name": self.destination_name,
-            "time_window": self.time_window,
+        return {
+            "origin": leg["origin"],
+            "origin_name": raw_data.get("location_name", leg["origin"]),
+            "destination": leg["destination"],
+            "destination_name": raw_data.get("destination_name", leg["destination"]),
             "services_tracked": len(services),
-            "total_services_found": len(data.get("services", [])),
+            "total_services_found": len(raw_data.get("services", [])),
             "services": services,
             "on_time_count": on_time_count,
             "delayed_count": delayed_count,
@@ -438,16 +527,130 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             "max_delay_minutes": delay_info["max_delay_minutes"],
             "disruption_reasons": delay_info["disruption_reasons"],
             "summary": summary,
-            "multi_destination": self.all_departures,
-            "last_updated": dt_util.now().isoformat(),
-            "next_update": (dt_util.now() + self.update_interval).isoformat(),
-            "nrcc_messages": data.get("nrcc_messages", []),
+            "nrcc_messages": raw_data.get("nrcc_messages", []),
         }
 
-        if self.all_departures:
-            result["services_by_destination"] = self._build_services_by_destination(services)
+    def _combine_statuses(self, statuses: list[str]) -> str:
+        """Combine per-leg statuses into one overall status (worst case wins).
 
-        return result
+        Args:
+            statuses: List of per-leg overall_status strings
+
+        Returns:
+            The most severe status across all legs, or Normal if empty
+        """
+        if not statuses:
+            return STATUS_NORMAL
+        return max(statuses, key=_STATUS_ORDER.index)
+
+    def _parse_data(
+        self, data: dict[str, Any] | list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Parse and enrich API data.
+
+        Args:
+            data: Raw API data for a single leg, or a list of raw API data
+                (one per leg, same order as self.legs) for a multi-leg journey
+
+        Returns:
+            Parsed data with additional calculated fields
+        """
+        if not self.is_multi_leg:
+            leg_result = self._parse_leg_data(self.legs[0], data)
+
+            result: dict[str, Any] = {
+                "origin": self.origin,
+                "origin_name": self.origin_name or self.origin,
+                "destination": self.destination,
+                "destination_name": self.destination_name,
+                "time_window": self.time_window,
+                "services_tracked": leg_result["services_tracked"],
+                "total_services_found": leg_result["total_services_found"],
+                "services": leg_result["services"],
+                "on_time_count": leg_result["on_time_count"],
+                "delayed_count": leg_result["delayed_count"],
+                "cancelled_count": leg_result["cancelled_count"],
+                "next_train": leg_result["next_train"],
+                "overall_status": leg_result[
+                    "overall_status"
+                ],  # Unified status for all sensors
+                "max_delay_minutes": leg_result["max_delay_minutes"],
+                "disruption_reasons": leg_result["disruption_reasons"],
+                "summary": leg_result["summary"],
+                "multi_destination": self.all_departures,
+                "last_updated": dt_util.now().isoformat(),
+                "next_update": (dt_util.now() + self.update_interval).isoformat(),
+                "nrcc_messages": leg_result["nrcc_messages"],
+            }
+
+            if self.all_departures:
+                result["services_by_destination"] = self._build_services_by_destination(
+                    leg_result["services"]
+                )
+
+            return result
+
+        # Multi-leg journey: data is a list of raw responses, one per leg
+        leg_results = [
+            self._parse_leg_data(leg, raw)
+            for leg, raw in zip(self.legs, data, strict=True)
+        ]
+
+        all_services: list[dict[str, Any]] = []
+        for leg_number, leg_result in enumerate(leg_results, start=1):
+            for service in leg_result["services"]:
+                tagged_service = dict(service)
+                tagged_service["leg"] = leg_number
+                all_services.append(tagged_service)
+
+        total_on_time = sum(lr["on_time_count"] for lr in leg_results)
+        total_delayed = sum(lr["delayed_count"] for lr in leg_results)
+        total_cancelled = sum(lr["cancelled_count"] for lr in leg_results)
+
+        disruption_reasons: list[str] = []
+        for lr in leg_results:
+            for reason in lr["disruption_reasons"]:
+                if reason not in disruption_reasons:
+                    disruption_reasons.append(reason)
+
+        nrcc_messages: list[Any] = []
+        for lr in leg_results:
+            for message in lr["nrcc_messages"]:
+                if message not in nrcc_messages:
+                    nrcc_messages.append(message)
+
+        return {
+            "origin": self.legs[0]["origin"],
+            "origin_name": leg_results[0]["origin_name"],
+            "destination": self.legs[-1]["destination"],
+            "destination_name": leg_results[-1]["destination_name"],
+            "time_window": self.time_window,
+            "services_tracked": sum(lr["services_tracked"] for lr in leg_results),
+            "total_services_found": sum(
+                lr["total_services_found"] for lr in leg_results
+            ),
+            "services": all_services,
+            "on_time_count": total_on_time,
+            "delayed_count": total_delayed,
+            "cancelled_count": total_cancelled,
+            "next_train": leg_results[0]["next_train"],
+            "overall_status": self._combine_statuses(
+                [lr["overall_status"] for lr in leg_results]
+            ),
+            "max_delay_minutes": max(
+                (lr["max_delay_minutes"] for lr in leg_results), default=0
+            ),
+            "disruption_reasons": disruption_reasons,
+            "summary": self._build_summary(
+                total_on_time, total_delayed, total_cancelled
+            ),
+            "multi_destination": False,
+            "is_multi_leg": True,
+            "legs": leg_results,
+            "last_updated": dt_util.now().isoformat(),
+            "next_update": (dt_util.now() + self.update_interval).isoformat(),
+            "nrcc_messages": nrcc_messages,
+        }
 
     def _collect_delay_info(self, services: list[dict[str, Any]]) -> dict[str, Any]:
         """Collect delay information for display attributes.
@@ -511,8 +714,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Get maximum delay from non-cancelled services
         max_delay = max(
-            (s.get("delay_minutes", 0) for s in services if not s.get("is_cancelled", False)),
-            default=0
+            (
+                s.get("delay_minutes", 0)
+                for s in services
+                if not s.get("is_cancelled", False)
+            ),
+            default=0,
         )
 
         # Check thresholds in priority order (high to low)

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -30,6 +30,8 @@ from .const import (
     ATTR_ESTIMATED_ARRIVAL,
     ATTR_EXPECTED_DEPARTURE,
     ATTR_IS_CANCELLED,
+    ATTR_IS_MULTI_LEG,
+    ATTR_LEGS,
     ATTR_ON_TIME_COUNT,
     ATTR_ON_TIME_COUNT_TODAY,
     ATTR_ON_TIME_PCT_7D,
@@ -63,9 +65,72 @@ from .const import (
     STATUS_NORMAL,
     STATUS_SEVERE_DISRUPTION,
 )
-from .coordinator import NationalRailDataUpdateCoordinator
+from .coordinator import NationalRailDataUpdateCoordinator, build_route_id
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_departure_status(train: dict[str, Any]) -> str:
+    """Get human-readable departure status.
+
+    Args:
+        train: Train data dictionary
+
+    Returns:
+        Status string like "On Time", "Delayed", "Cancelled"
+    """
+    if train.get("is_cancelled"):
+        return "Cancelled"
+
+    delay_minutes = train.get("delay_minutes", 0)
+    if delay_minutes > 0:
+        return "Delayed"
+
+    expected = train.get("expected_departure")
+    scheduled = train.get("scheduled_departure")
+
+    if expected and expected != scheduled:
+        return "Expected"
+
+    return "On Time"
+
+
+def _build_all_trains_attribute(services: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build the all_trains attribute payload from a list of services.
+
+    Args:
+        services: List of service data dicts
+
+    Returns:
+        List of per-train dicts suitable for custom Lovelace cards
+    """
+    all_trains = []
+    for idx, service in enumerate(services, start=1):
+        train_data = {
+            "train_number": idx,
+            "scheduled_departure": service.get("scheduled_departure"),
+            "expected_departure": service.get("expected_departure"),
+            "platform": service.get("platform"),
+            "operator": service.get("operator"),
+            "service_id": service.get("service_id"),
+            "status": service.get("status"),
+            "delay_minutes": service.get("delay_minutes", 0),
+            "is_cancelled": service.get("is_cancelled", False),
+            "calling_points": service.get("calling_points", []),
+            "estimated_arrival": service.get("estimated_arrival"),
+            "scheduled_arrival": service.get("scheduled_arrival"),
+            "destination": service.get("destination"),
+        }
+
+        # Add optional fields if present
+        if service.get("cancellation_reason"):
+            train_data["cancellation_reason"] = service.get("cancellation_reason")
+        if service.get("delay_reason"):
+            train_data["delay_reason"] = service.get("delay_reason")
+
+        all_trains.append(train_data)
+
+    return all_trains
 
 
 async def async_setup_entry(
@@ -90,12 +155,27 @@ async def async_setup_entry(
     entities: list[SensorEntity] = [
         CommuteSummarySensor(coordinator, entry),
         CommuteStatusSensor(coordinator, entry),
-        NextTrainSensor(coordinator, entry),  # Mirrors train_1 for convenience
     ]
 
-    # Create individual train sensors dynamically based on configuration
-    for train_number in range(1, num_trains + 1):
-        entities.append(TrainSensor(coordinator, entry, train_number))
+    if coordinator.is_multi_leg:
+        # Per-leg sensors replace the flat next-train/train-N range: each leg
+        # has its own summary, status, next train, and tracked-train sensors
+        for leg_index in range(1, len(coordinator.legs) + 1):
+            entities.append(LegSummarySensor(coordinator, entry, leg_index))
+            entities.append(LegStatusSensor(coordinator, entry, leg_index))
+            entities.append(LegNextTrainSensor(coordinator, entry, leg_index))
+            for train_number in range(1, num_trains + 1):
+                entities.append(
+                    LegTrainSensor(coordinator, entry, leg_index, train_number)
+                )
+    else:
+        entities.append(
+            NextTrainSensor(coordinator, entry)
+        )  # Mirrors train_1 for convenience
+
+        # Create individual train sensors dynamically based on configuration
+        for train_number in range(1, num_trains + 1):
+            entities.append(TrainSensor(coordinator, entry, train_number))
 
     # Historical performance sensors
     entities.append(HistoricalReliabilitySensor(coordinator, entry))
@@ -132,12 +212,7 @@ class NationalRailCommuteEntity(CoordinatorEntity[NationalRailDataUpdateCoordina
 
         # Create device info
         commute_name = entry.data.get(CONF_COMMUTE_NAME, "My Rail Commute")
-        origin = coordinator.origin
-        destination = coordinator.destination
-
-        device_id = (
-            f"{origin}_{destination}" if destination else f"{origin}_all_departures"
-        )
+        device_id = build_route_id(coordinator.legs)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
             name=commute_name,
@@ -193,31 +268,7 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
         services = data.get("services", [])
 
         # Build all_trains attribute with complete train data for custom cards
-        all_trains = []
-        for idx, service in enumerate(services, start=1):
-            train_data = {
-                "train_number": idx,
-                "scheduled_departure": service.get("scheduled_departure"),
-                "expected_departure": service.get("expected_departure"),
-                "platform": service.get("platform"),
-                "operator": service.get("operator"),
-                "service_id": service.get("service_id"),
-                "status": service.get("status"),
-                "delay_minutes": service.get("delay_minutes", 0),
-                "is_cancelled": service.get("is_cancelled", False),
-                "calling_points": service.get("calling_points", []),
-                "estimated_arrival": service.get("estimated_arrival"),
-                "scheduled_arrival": service.get("scheduled_arrival"),
-                "destination": service.get("destination"),
-            }
-
-            # Add optional fields if present
-            if service.get("cancellation_reason"):
-                train_data["cancellation_reason"] = service.get("cancellation_reason")
-            if service.get("delay_reason"):
-                train_data["delay_reason"] = service.get("delay_reason")
-
-            all_trains.append(train_data)
+        all_trains = _build_all_trains_attribute(services)
 
         attrs: dict[str, Any] = {
             ATTR_ORIGIN: data.get("origin"),
@@ -289,6 +340,10 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
             attrs["multi_destination"] = True
             attrs["services_by_destination"] = data.get("services_by_destination", {})
 
+        if data.get("is_multi_leg"):
+            attrs[ATTR_IS_MULTI_LEG] = True
+            attrs[ATTR_LEGS] = data.get("legs", [])
+
         return attrs
 
 
@@ -320,6 +375,17 @@ class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}_status"
         self._attr_icon = "mdi:train"
 
+    def _get_route_data(self) -> dict[str, Any] | None:
+        """Return the dict this sensor reports on (whole journey by default).
+
+        Overridden by leg-scoped subclasses to read from a single leg's
+        parsed data instead of the whole journey's.
+
+        Returns:
+            The route data dict, or None if unavailable
+        """
+        return self.coordinator.data
+
     @property
     def native_value(self) -> str | None:
         """Return the state of the sensor.
@@ -329,11 +395,12 @@ class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):
         Returns:
             Status: Normal, Minor Delays, Major Delays, Severe Disruption, or Critical
         """
-        if not self.coordinator.data:
+        data = self._get_route_data()
+        if not data:
             return None
 
         # Use the unified status from coordinator (single source of truth)
-        return self.coordinator.data.get("overall_status", STATUS_NORMAL)
+        return data.get("overall_status", STATUS_NORMAL)
 
     @property
     def icon(self) -> str:
@@ -371,10 +438,10 @@ class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):
         Returns:
             Dictionary of attributes
         """
-        if not self.coordinator.data:
+        data = self._get_route_data()
+        if not data:
             return {}
 
-        data = self.coordinator.data
         services = data.get("services", [])
 
         # Calculate statistics
@@ -420,7 +487,7 @@ class CommuteStatusSensor(NationalRailCommuteEntity, SensorEntity):
             ATTR_ORIGIN_NAME: data.get("origin_name"),
             ATTR_DESTINATION: data.get("destination"),
             ATTR_DESTINATION_NAME: data.get("destination_name"),
-            "last_updated": data.get("last_updated"),
+            "last_updated": (self.coordinator.data or {}).get("last_updated"),
         }
 
 
@@ -457,6 +524,19 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
         else:
             self._attr_icon = "mdi:train"
 
+    def _get_services(self) -> list[dict[str, Any]]:
+        """Return the list of services this sensor tracks.
+
+        Overridden by leg-scoped subclasses to read from a single leg's
+        service list instead of the whole journey's.
+
+        Returns:
+            List of service data dicts
+        """
+        if not self.coordinator.data:
+            return []
+        return self.coordinator.data.get("services", [])
+
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator and detect platform changes."""
         if not self.coordinator.data:
@@ -464,7 +544,7 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
             super()._handle_coordinator_update()
             return
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
         _LOGGER.debug(
             "Train %d: Processing update with %d services available",
             self._train_number,
@@ -537,7 +617,7 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
         if not self.coordinator.data:
             return None
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
 
         # Check if this train exists in the service list
         if len(services) < self._train_number:
@@ -546,7 +626,7 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
         train = services[self._train_number - 1]
 
         # Return departure status
-        return self._get_departure_status(train)
+        return _get_departure_status(train)
 
     @property
     def icon(self) -> str:
@@ -558,7 +638,7 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
         if not self.coordinator.data:
             return "mdi:train"
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
 
         if len(services) < self._train_number:
             return "mdi:train"
@@ -590,7 +670,7 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
                 "status": "unavailable",
             }
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
 
         # If this train doesn't exist, return minimal attributes
         if len(services) < self._train_number:
@@ -644,30 +724,6 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
 
         return attributes
 
-    def _get_departure_status(self, train: dict[str, Any]) -> str:
-        """Get human-readable departure status.
-
-        Args:
-            train: Train data dictionary
-
-        Returns:
-            Status string like "On Time", "Delayed", "Cancelled"
-        """
-        if train.get("is_cancelled"):
-            return "Cancelled"
-
-        delay_minutes = train.get("delay_minutes", 0)
-        if delay_minutes > 0:
-            return "Delayed"
-
-        expected = train.get("expected_departure")
-        scheduled = train.get("scheduled_departure")
-
-        if expected and expected != scheduled:
-            return "Expected"
-
-        return "On Time"
-
 
 class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
     """Convenience sensor that mirrors train_1 (next departing train)."""
@@ -694,13 +750,26 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
         self._platform_changed: bool = False
         self._current_service_id: str | None = None
 
+    def _get_services(self) -> list[dict[str, Any]]:
+        """Return the list of services this sensor tracks.
+
+        Overridden by leg-scoped subclasses to read from a single leg's
+        service list instead of the whole journey's.
+
+        Returns:
+            List of service data dicts
+        """
+        if not self.coordinator.data:
+            return []
+        return self.coordinator.data.get("services", [])
+
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator and detect platform changes."""
         if not self.coordinator.data:
             super()._handle_coordinator_update()
             return
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
 
         # Check if next train exists
         if services:
@@ -766,7 +835,7 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
         if not self.coordinator.data:
             return None
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
 
         # If no trains at all, show "No service" instead of unavailable
         if not services:
@@ -776,7 +845,7 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
         train = services[0]
 
         # Return departure status
-        return self._get_departure_status(train)
+        return _get_departure_status(train)
 
     @property
     def icon(self) -> str:
@@ -788,7 +857,7 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
         if not self.coordinator.data:
             return "mdi:train-car"
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
 
         if not services:
             return "mdi:train-car"
@@ -819,7 +888,7 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
                 "status": "unavailable",
             }
 
-        services = self.coordinator.data.get("services", [])
+        services = self._get_services()
 
         # If no trains, return appropriate status
         if not services:
@@ -871,29 +940,175 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
 
         return attributes
 
-    def _get_departure_status(self, train: dict[str, Any]) -> str:
-        """Get human-readable departure status.
+
+class LegSummarySensor(NationalRailCommuteEntity, SensorEntity):
+    """Sensor for a single leg's summary within a multi-leg journey."""
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+        leg_index: int,
+    ) -> None:
+        """Initialize the leg summary sensor.
 
         Args:
-            train: Train data dictionary
+            coordinator: Data coordinator
+            entry: Config entry
+            leg_index: 1-indexed position of this leg in the journey
+        """
+        super().__init__(coordinator, entry)
+
+        self._leg_index = leg_index
+        self._attr_name = f"Leg {leg_index} Summary"
+        self._attr_unique_id = f"{entry.entry_id}_leg{leg_index}_summary"
+        self._attr_icon = "mdi:train"
+
+    def _get_leg_data(self) -> dict[str, Any] | None:
+        """Return this sensor's leg's parsed data, or None if unavailable."""
+        if not self.coordinator.data:
+            return None
+        legs = self.coordinator.data.get("legs", [])
+        if len(legs) < self._leg_index:
+            return None
+        return legs[self._leg_index - 1]
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor.
 
         Returns:
-            Status string like "On Time", "Delayed", "Cancelled"
+            Summary text or None if unavailable
         """
-        if train.get("is_cancelled"):
-            return "Cancelled"
+        leg_data = self._get_leg_data()
+        if not leg_data:
+            return None
+        return leg_data.get("summary")
 
-        delay_minutes = train.get("delay_minutes", 0)
-        if delay_minutes > 0:
-            return "Delayed"
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes.
 
-        expected = train.get("expected_departure")
-        scheduled = train.get("scheduled_departure")
+        Returns:
+            Dictionary of attributes including all_trains for custom cards
+        """
+        leg_data = self._get_leg_data()
+        if not leg_data:
+            return {}
 
-        if expected and expected != scheduled:
-            return "Expected"
+        services = leg_data.get("services", [])
 
-        return "On Time"
+        return {
+            ATTR_ORIGIN: leg_data.get("origin"),
+            ATTR_ORIGIN_NAME: leg_data.get("origin_name"),
+            ATTR_DESTINATION: leg_data.get("destination"),
+            ATTR_DESTINATION_NAME: leg_data.get("destination_name"),
+            ATTR_SERVICES_TRACKED: leg_data.get("services_tracked"),
+            ATTR_TOTAL_SERVICES: leg_data.get("total_services_found"),
+            ATTR_ON_TIME_COUNT: leg_data.get("on_time_count"),
+            ATTR_DELAYED_COUNT: leg_data.get("delayed_count"),
+            ATTR_CANCELLED_COUNT: leg_data.get("cancelled_count"),
+            "all_trains": _build_all_trains_attribute(services),
+            "last_updated": (self.coordinator.data or {}).get("last_updated"),
+        }
+
+
+class LegStatusSensor(CommuteStatusSensor):
+    """Sensor for a single leg's status within a multi-leg journey."""
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+        leg_index: int,
+    ) -> None:
+        """Initialize the leg status sensor.
+
+        Args:
+            coordinator: Data coordinator
+            entry: Config entry
+            leg_index: 1-indexed position of this leg in the journey
+        """
+        self._leg_index = leg_index
+        super().__init__(coordinator, entry)
+
+        self._attr_name = f"Leg {leg_index} Status"
+        self._attr_unique_id = f"{entry.entry_id}_leg{leg_index}_status"
+
+    def _get_route_data(self) -> dict[str, Any] | None:
+        """Return this sensor's leg's parsed data, or None if unavailable."""
+        if not self.coordinator.data:
+            return None
+        legs = self.coordinator.data.get("legs", [])
+        if len(legs) < self._leg_index:
+            return None
+        return legs[self._leg_index - 1]
+
+
+class LegTrainSensor(TrainSensor):
+    """Sensor for individual train information within one leg of a multi-leg journey."""
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+        leg_index: int,
+        train_number: int,
+    ) -> None:
+        """Initialize the leg train sensor.
+
+        Args:
+            coordinator: Data coordinator
+            entry: Config entry
+            leg_index: 1-indexed position of this leg in the journey
+            train_number: Position in this leg's departure list (1 = next train)
+        """
+        self._leg_index = leg_index
+        super().__init__(coordinator, entry, train_number)
+
+        self._attr_name = f"Leg {leg_index} Train {train_number}"
+        self._attr_unique_id = f"{entry.entry_id}_leg{leg_index}_train_{train_number}"
+
+    def _get_services(self) -> list[dict[str, Any]]:
+        """Return this leg's list of services, or an empty list if unavailable."""
+        if not self.coordinator.data:
+            return []
+        legs = self.coordinator.data.get("legs", [])
+        if len(legs) < self._leg_index:
+            return []
+        return legs[self._leg_index - 1].get("services", [])
+
+
+class LegNextTrainSensor(NextTrainSensor):
+    """Convenience sensor that mirrors leg_train_1 for one leg of a multi-leg journey."""
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+        leg_index: int,
+    ) -> None:
+        """Initialize the leg next-train sensor.
+
+        Args:
+            coordinator: Data coordinator
+            entry: Config entry
+            leg_index: 1-indexed position of this leg in the journey
+        """
+        self._leg_index = leg_index
+        super().__init__(coordinator, entry)
+
+        self._attr_name = f"Leg {leg_index} Next Train"
+        self._attr_unique_id = f"{entry.entry_id}_leg{leg_index}_next_train"
+
+    def _get_services(self) -> list[dict[str, Any]]:
+        """Return this leg's list of services, or an empty list if unavailable."""
+        if not self.coordinator.data:
+            return []
+        legs = self.coordinator.data.get("legs", [])
+        if len(legs) < self._leg_index:
+            return []
+        return legs[self._leg_index - 1].get("services", [])
 
 
 class HistoricalReliabilitySensor(NationalRailCommuteEntity, SensorEntity):

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -17,6 +17,14 @@
           "destination": "Destination Station (CRS Code) — leave blank if 'All Departures' is enabled"
         }
       },
+      "add_leg": {
+        "title": "Add a Connecting Leg",
+        "description": "Your journey so far: {itinerary}\n\nDoes this journey require a change of train? Add a connecting leg departing from {destination}, or continue if your itinerary is complete.",
+        "data": {
+          "add_leg": "Add a connecting leg",
+          "leg_destination": "Next Destination Station (CRS Code)"
+        }
+      },
       "settings": {
         "title": "Commute Settings",
         "description": "Configure settings for your commute from {origin} to {destination}.",

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -17,6 +17,14 @@
           "destination": "Destination Station (CRS Code) — leave blank if 'All Departures' is enabled"
         }
       },
+      "add_leg": {
+        "title": "Add a Connecting Leg",
+        "description": "Your journey so far: {itinerary}\n\nDoes this journey require a change of train? Add a connecting leg departing from {destination}, or continue if your itinerary is complete.",
+        "data": {
+          "add_leg": "Add a connecting leg",
+          "leg_destination": "Next Destination Station (CRS Code)"
+        }
+      },
       "settings": {
         "title": "Commute Settings",
         "description": "Configure settings for your commute from {origin} to {destination}.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,7 @@ from custom_components.my_rail_commute.config_flow import (
     validate_stations,
 )
 from custom_components.my_rail_commute.const import (
+    CONF_ADD_LEG,
     CONF_ADD_RETURN_JOURNEY,
     CONF_COMMUTE_NAME,
     CONF_DESTINATION,
@@ -280,6 +281,15 @@ class TestConfigFlow:
             )
 
             assert result["type"] == data_entry_flow.FlowResultType.FORM
+            assert result["step_id"] == "add_leg"
+
+            # Decline adding a connecting leg to proceed to settings
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: False},
+            )
+
+            assert result["type"] == data_entry_flow.FlowResultType.FORM
             assert result["step_id"] == "settings"
 
     async def test_complete_flow_creates_entry(self, hass: HomeAssistant):
@@ -308,7 +318,13 @@ class TestConfigFlow:
                 user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
             )
 
-        # Step 3: Settings
+        # Step 3: Decline adding a connecting leg
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ADD_LEG: False},
+        )
+
+        # Step 4: Settings
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -367,6 +383,12 @@ class TestConfigFlow:
                 result["flow_id"],
                 user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
             )
+
+        # Decline adding a connecting leg
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ADD_LEG: False},
+        )
         return result
 
     async def _submit_settings(self, hass, flow_id):
@@ -485,7 +507,13 @@ class TestConfigFlow:
                 user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
             )
 
-        # Step 3: Settings - should abort due to duplicate unique_id
+        # Step 3: Decline adding a connecting leg
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ADD_LEG: False},
+        )
+
+        # Step 4: Settings - should abort due to duplicate unique_id
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -773,6 +801,11 @@ class TestStationsStepLocationBased:
                 user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
             )
 
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ADD_LEG: False},
+        )
+
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "settings"
 
@@ -796,6 +829,11 @@ class TestStationsStepLocationBased:
                 result["flow_id"],
                 user_input={CONF_ORIGIN: "MAN", CONF_DESTINATION: "LDS"},
             )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ADD_LEG: False},
+        )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "settings"

--- a/tests/test_config_flow_multi_leg.py
+++ b/tests/test_config_flow_multi_leg.py
@@ -1,0 +1,314 @@
+"""Tests for multi-leg journey support in the config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+from custom_components.my_rail_commute.const import (
+    CONF_ADD_LEG,
+    CONF_ADD_RETURN_JOURNEY,
+    CONF_COMMUTE_NAME,
+    CONF_DESTINATION,
+    CONF_LEG_DESTINATION,
+    CONF_LEGS,
+    CONF_MAJOR_DELAY_THRESHOLD,
+    CONF_MINOR_DELAY_THRESHOLD,
+    CONF_NIGHT_UPDATES,
+    CONF_NUM_SERVICES,
+    CONF_ORIGIN,
+    CONF_SEVERE_DELAY_THRESHOLD,
+    CONF_TIME_WINDOW,
+    DEFAULT_MAJOR_DELAY_THRESHOLD,
+    DEFAULT_MINOR_DELAY_THRESHOLD,
+    DEFAULT_SEVERE_DELAY_THRESHOLD,
+    DOMAIN,
+)
+
+
+async def _start_flow(hass: HomeAssistant):
+    """Start the flow and submit a valid API key."""
+    with patch(
+        "custom_components.my_rail_commute.config_flow.validate_api_key",
+        return_value={"title": "My Rail Commute"},
+    ):
+        return await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={CONF_API_KEY: "valid_key"},
+        )
+
+
+async def _submit_settings(hass: HomeAssistant, flow_id: str):
+    """Submit the settings step with default values."""
+    return await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={
+            CONF_COMMUTE_NAME: "Test Journey",
+            CONF_TIME_WINDOW: 60,
+            CONF_NUM_SERVICES: 3,
+            CONF_NIGHT_UPDATES: False,
+            CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+            CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+            CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+        },
+    )
+
+
+class TestAddLegStep:
+    """Tests for the add_leg looping step."""
+
+    async def test_declining_first_leg_creates_single_leg_entry(
+        self, hass: HomeAssistant
+    ):
+        """Declining to add a leg produces a plain single-leg entry (no CONF_LEGS)."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+
+        assert result["step_id"] == "add_leg"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_LEG: False}
+        )
+        assert result["step_id"] == "settings"
+
+        result = await _submit_settings(hass, result["flow_id"])
+        assert result["step_id"] == "return_journey"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert CONF_LEGS not in result["data"]
+        assert result["data"][CONF_ORIGIN] == "PAD"
+        assert result["data"][CONF_DESTINATION] == "RDG"
+
+    async def test_adding_two_legs_persists_full_chain(self, hass: HomeAssistant):
+        """Accepting add_leg twice then declining persists a 3-leg CONF_LEGS list."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+        assert result["step_id"] == "add_leg"
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={"origin_name": "Reading", "destination_name": "Oxford"},
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "OXF"},
+            )
+        assert result["step_id"] == "add_leg"
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "Oxford",
+                "destination_name": "Birmingham New Street",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "BHM"},
+            )
+        assert result["step_id"] == "add_leg"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_LEG: False}
+        )
+        assert result["step_id"] == "settings"
+
+        result = await _submit_settings(hass, result["flow_id"])
+        assert result["step_id"] == "return_journey"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_LEGS] == [
+            {"origin": "PAD", "destination": "RDG"},
+            {"origin": "RDG", "destination": "OXF"},
+            {"origin": "OXF", "destination": "BHM"},
+        ]
+        # Convenience flat origin/destination reflect the whole chain's endpoints
+        assert result["data"][CONF_ORIGIN] == "PAD"
+        assert result["data"][CONF_DESTINATION] == "BHM"
+
+    async def test_unique_id_is_chain_based_for_multi_leg(self, hass: HomeAssistant):
+        """The config entry's unique_id embeds every station in the chain."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={"origin_name": "Reading", "destination_name": "Oxford"},
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "OXF"},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_LEG: False}
+        )
+        result = await _submit_settings(hass, result["flow_id"])
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        entries = hass.config_entries.async_entries(DOMAIN)
+        assert len(entries) == 1
+        assert entries[0].unique_id == "PAD_RDG_OXF"
+
+    async def test_add_leg_same_station_shows_error(self, hass: HomeAssistant):
+        """Requesting a leg destination identical to the current station errors."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            side_effect=ValueError("Origin and destination must be different"),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "RDG"},
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "add_leg"
+        assert result["errors"] == {"base": "same_station"}
+
+    async def test_add_leg_missing_destination_shows_error(self, hass: HomeAssistant):
+        """Accepting add_leg without a destination shows a required-field error."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: ""},
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "add_leg"
+        assert result["errors"] == {CONF_LEG_DESTINATION: "required"}
+
+
+class TestMultiLegReturnJourney:
+    """Tests for the return-journey toggle reversing the full leg chain."""
+
+    async def test_return_journey_reverses_full_leg_sequence(self, hass: HomeAssistant):
+        """Accepting the return-journey offer reverses both leg order and direction."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={"origin_name": "Reading", "destination_name": "Oxford"},
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "OXF"},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_LEG: False}
+        )
+        result = await _submit_settings(hass, result["flow_id"])
+        assert result["step_id"] == "return_journey"
+
+        with patch.object(
+            hass.config_entries.flow,
+            "async_init",
+            wraps=hass.config_entries.flow.async_init,
+        ) as mock_init:
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_RETURN_JOURNEY: True},
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert mock_init.call_count == 1
+        reverse_data = mock_init.call_args.kwargs["data"]
+
+        assert reverse_data[CONF_LEGS] == [
+            {"origin": "OXF", "destination": "RDG"},
+            {"origin": "RDG", "destination": "PAD"},
+        ]
+        assert reverse_data[CONF_ORIGIN] == "OXF"
+        assert reverse_data[CONF_DESTINATION] == "PAD"
+
+        # The reverse import flow itself must persist CONF_LEGS and use a
+        # chain-based unique_id, not just the overall origin/destination
+        entries = hass.config_entries.async_entries(DOMAIN)
+        reverse_entry = next(e for e in entries if e.unique_id == "OXF_RDG_PAD")
+        assert reverse_entry.data[CONF_LEGS] == reverse_data[CONF_LEGS]

--- a/tests/test_coordinator_multi_leg.py
+++ b/tests/test_coordinator_multi_leg.py
@@ -1,0 +1,354 @@
+"""Tests for multi-leg journey support in the coordinator."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.my_rail_commute.api import NationalRailAPIError
+from custom_components.my_rail_commute.const import (
+    CONF_DESTINATION,
+    CONF_LEGS,
+    CONF_MAJOR_DELAY_THRESHOLD,
+    CONF_MINOR_DELAY_THRESHOLD,
+    CONF_NIGHT_UPDATES,
+    CONF_NUM_SERVICES,
+    CONF_ORIGIN,
+    CONF_SEVERE_DELAY_THRESHOLD,
+    CONF_TIME_WINDOW,
+    DEFAULT_MAJOR_DELAY_THRESHOLD,
+    DEFAULT_MINOR_DELAY_THRESHOLD,
+    DEFAULT_SEVERE_DELAY_THRESHOLD,
+    STATUS_CANCELLED,
+    STATUS_CRITICAL,
+    STATUS_DELAYED,
+    STATUS_MAJOR_DELAYS,
+    STATUS_MINOR_DELAYS,
+    STATUS_NORMAL,
+    STATUS_ON_TIME,
+    STATUS_SEVERE_DISRUPTION,
+)
+from custom_components.my_rail_commute.coordinator import (
+    NationalRailDataUpdateCoordinator,
+    build_route_id,
+)
+
+_TEST_TIME = datetime(2024, 1, 15, 8, 0, 0, tzinfo=dt_util.UTC)
+
+
+def _make_service(
+    service_id: str, status: str = STATUS_ON_TIME, delay_minutes: int = 0
+) -> dict:
+    """Build a minimal already-parsed service dict."""
+    is_cancelled = status == STATUS_CANCELLED
+    return {
+        "scheduled_departure": "09:00",
+        "expected_departure": "09:00" if delay_minutes == 0 else "09:10",
+        "platform": "1",
+        "operator": "Test Operator",
+        "service_id": service_id,
+        "calling_points": [],
+        "delay_minutes": delay_minutes,
+        "status": status,
+        "is_cancelled": is_cancelled,
+        "cancellation_reason": "Signal failure" if is_cancelled else None,
+        "delay_reason": "Late running" if delay_minutes else None,
+        "scheduled_arrival": "09:30",
+        "estimated_arrival": "09:30",
+        "destination": "Destination",
+    }
+
+
+def _make_leg_response(origin_name: str, destination_name: str, services: list) -> dict:
+    """Build a raw get_departure_board response for one leg."""
+    return {
+        "location_name": origin_name,
+        "destination_name": destination_name,
+        "services": services,
+        "generated_at": "2024-01-15T08:00:00",
+        "nrcc_messages": [],
+    }
+
+
+def _make_config(legs: list[dict]) -> dict:
+    """Build a multi-leg config dict."""
+    return {
+        CONF_API_KEY: "test_key",
+        CONF_ORIGIN: legs[0]["origin"],
+        CONF_DESTINATION: legs[-1]["destination"],
+        CONF_LEGS: legs,
+        CONF_TIME_WINDOW: 60,
+        CONF_NUM_SERVICES: 3,
+        CONF_NIGHT_UPDATES: True,
+        CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+        CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+        CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+    }
+
+
+def test_build_route_id_single_leg_matches_legacy_format():
+    """Single-leg route id is byte-identical to the historical format."""
+    legs = [{"origin": "PAD", "destination": "RDG"}]
+    assert build_route_id(legs) == "PAD_RDG"
+
+
+def test_build_route_id_all_departures():
+    """All-departures single leg uses the historical suffix."""
+    legs = [{"origin": "PAD", "destination": None}]
+    assert build_route_id(legs) == "PAD_all_departures"
+
+
+def test_build_route_id_multi_leg_chain():
+    """Multi-leg route id embeds every intermediate station."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    assert build_route_id(legs) == "PAD_RDG_OXF"
+
+
+def test_build_route_id_distinguishes_different_interchanges():
+    """Two chains sharing endpoints but different interchanges never collide."""
+    via_rdg = build_route_id(
+        [{"origin": "A", "destination": "RDG"}, {"origin": "RDG", "destination": "D"}]
+    )
+    via_oxf = build_route_id(
+        [{"origin": "A", "destination": "OXF"}, {"origin": "OXF", "destination": "D"}]
+    )
+    assert via_rdg != via_oxf
+
+
+async def test_coordinator_parses_legs_from_config(hass: HomeAssistant) -> None:
+    """The coordinator wraps a single origin/destination into one leg by default."""
+    api = AsyncMock()
+    coordinator = NationalRailDataUpdateCoordinator(
+        hass,
+        api,
+        {
+            CONF_API_KEY: "test_key",
+            CONF_ORIGIN: "PAD",
+            CONF_DESTINATION: "RDG",
+            CONF_TIME_WINDOW: 60,
+            CONF_NUM_SERVICES: 3,
+            CONF_NIGHT_UPDATES: True,
+            CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+            CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+            CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+        },
+    )
+
+    assert coordinator.is_multi_leg is False
+    assert coordinator.legs == [{"origin": "PAD", "destination": "RDG"}]
+
+
+async def test_coordinator_reads_multi_leg_config(hass: HomeAssistant) -> None:
+    """CONF_LEGS is parsed into coordinator.legs and marks is_multi_leg."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    api = AsyncMock()
+    coordinator = NationalRailDataUpdateCoordinator(hass, api, _make_config(legs))
+
+    assert coordinator.is_multi_leg is True
+    assert coordinator.legs == legs
+    assert coordinator.origin == "PAD"
+    assert coordinator.destination == "OXF"
+
+
+async def test_multi_leg_update_fetches_each_leg_sequentially(
+    hass: HomeAssistant,
+) -> None:
+    """Each leg is fetched with its own origin/destination, in order."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [_make_service("svc1")]),
+            _make_leg_response("Reading", "Oxford", [_make_service("svc2")]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(hass, api, _make_config(legs))
+        data = await coordinator._async_update_data()
+
+    assert api.get_departure_board.call_count == 2
+    first_call, second_call = api.get_departure_board.call_args_list
+    assert first_call.args[0] == "PAD"
+    assert first_call.kwargs["destination_crs"] == "RDG"
+    assert second_call.args[0] == "RDG"
+    assert second_call.kwargs["destination_crs"] == "OXF"
+
+    assert data["is_multi_leg"] is True
+    assert len(data["legs"]) == 2
+    assert data["origin"] == "PAD"
+    assert data["destination"] == "OXF"
+
+
+async def test_multi_leg_services_are_concatenated_and_tagged_with_leg(
+    hass: HomeAssistant,
+) -> None:
+    """Top-level services concatenate every leg's services, tagged with leg number."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [_make_service("svc1")]),
+            _make_leg_response(
+                "Reading", "Oxford", [_make_service("svc2"), _make_service("svc3")]
+            ),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(hass, api, _make_config(legs))
+        data = await coordinator._async_update_data()
+
+    assert [s["service_id"] for s in data["services"]] == ["svc1", "svc2", "svc3"]
+    assert [s["leg"] for s in data["services"]] == [1, 2, 2]
+    assert data["services_tracked"] == 3
+    assert data["on_time_count"] == 3
+
+
+@pytest.mark.parametrize(
+    ("leg1_status_kwargs", "leg2_status_kwargs", "expected_overall"),
+    [
+        ({}, {}, STATUS_NORMAL),
+        ({"delay_minutes": 5}, {}, STATUS_MINOR_DELAYS),
+        ({}, {"delay_minutes": 12}, STATUS_MAJOR_DELAYS),
+        ({"delay_minutes": 20}, {}, STATUS_SEVERE_DISRUPTION),
+        ({}, {"status": STATUS_CANCELLED}, STATUS_CRITICAL),
+        ({"status": STATUS_CANCELLED}, {"delay_minutes": 20}, STATUS_CRITICAL),
+    ],
+)
+async def test_multi_leg_overall_status_is_worst_case_across_legs(
+    hass: HomeAssistant, leg1_status_kwargs, leg2_status_kwargs, expected_overall
+) -> None:
+    """overall_status reflects the most severe status across all legs."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    leg1_service = _make_service("svc1", **leg1_status_kwargs)
+    leg2_service = _make_service("svc2", **leg2_status_kwargs)
+    if leg1_status_kwargs.get("delay_minutes"):
+        leg1_service["status"] = STATUS_DELAYED
+    if leg2_status_kwargs.get("delay_minutes"):
+        leg2_service["status"] = STATUS_DELAYED
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [leg1_service]),
+            _make_leg_response("Reading", "Oxford", [leg2_service]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(hass, api, _make_config(legs))
+        data = await coordinator._async_update_data()
+
+    assert data["overall_status"] == expected_overall
+
+
+async def test_multi_leg_leg_failure_propagates_like_single_leg(
+    hass: HomeAssistant,
+) -> None:
+    """A failure fetching any leg raises UpdateFailed, same as a single-leg failure."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [_make_service("svc1")]),
+            NationalRailAPIError("boom"),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(hass, api, _make_config(legs))
+        coordinator._max_failed_updates = 1
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+
+async def test_single_leg_output_shape_unchanged(hass: HomeAssistant) -> None:
+    """Single-leg _parse_data output has exactly the same keys as before the refactor."""
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        return_value=_make_leg_response(
+            "Paddington", "Reading", [_make_service("svc1")]
+        )
+    )
+
+    config = {
+        CONF_API_KEY: "test_key",
+        CONF_ORIGIN: "PAD",
+        CONF_DESTINATION: "RDG",
+        CONF_TIME_WINDOW: 60,
+        CONF_NUM_SERVICES: 3,
+        CONF_NIGHT_UPDATES: True,
+        CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+        CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+        CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+    }
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(hass, api, config)
+        data = await coordinator._async_update_data()
+
+    expected_keys = {
+        "origin",
+        "origin_name",
+        "destination",
+        "destination_name",
+        "time_window",
+        "services_tracked",
+        "total_services_found",
+        "services",
+        "on_time_count",
+        "delayed_count",
+        "cancelled_count",
+        "next_train",
+        "overall_status",
+        "max_delay_minutes",
+        "disruption_reasons",
+        "summary",
+        "multi_destination",
+        "last_updated",
+        "next_update",
+        "nrcc_messages",
+    }
+    assert set(data.keys()) == expected_keys
+    assert "is_multi_leg" not in data
+    assert "legs" not in data

--- a/tests/test_init_cleanup.py
+++ b/tests/test_init_cleanup.py
@@ -1,0 +1,54 @@
+"""Tests for stale train-entity cleanup, including leg-scoped entities."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.my_rail_commute import async_cleanup_stale_entities
+from custom_components.my_rail_commute.const import CONF_NUM_SERVICES, DOMAIN
+
+
+async def test_cleanup_removes_stale_single_leg_and_leg_scoped_train_entities(
+    hass: HomeAssistant,
+) -> None:
+    """Reducing num_services removes excess train sensors for every leg."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NUM_SERVICES: 3},
+        unique_id="PAD_RDG_OXF",
+    )
+    entry.add_to_hass(hass)
+
+    entity_reg = er.async_get(hass)
+    kept_and_removed = {
+        # Legacy single-leg shape
+        f"{entry.entry_id}_train_1": True,
+        f"{entry.entry_id}_train_3": True,
+        f"{entry.entry_id}_train_5": False,
+        # Leg-scoped shape
+        f"{entry.entry_id}_leg1_train_1": True,
+        f"{entry.entry_id}_leg1_train_3": True,
+        f"{entry.entry_id}_leg1_train_5": False,
+        f"{entry.entry_id}_leg2_train_2": True,
+        f"{entry.entry_id}_leg2_train_4": False,
+        # Non-train entities must never be touched
+        f"{entry.entry_id}_summary": True,
+        f"{entry.entry_id}_leg1_status": True,
+    }
+
+    entity_ids = {}
+    for unique_id in kept_and_removed:
+        entity = entity_reg.async_get_or_create(
+            "sensor", DOMAIN, unique_id, config_entry=entry
+        )
+        entity_ids[unique_id] = entity.entity_id
+
+    await async_cleanup_stale_entities(hass, entry)
+
+    for unique_id, should_be_kept in kept_and_removed.items():
+        still_exists = entity_reg.async_get(entity_ids[unique_id]) is not None
+        assert still_exists == should_be_kept, (
+            f"{unique_id}: expected kept={should_be_kept}"
+        )

--- a/tests/test_sensor_multi_leg.py
+++ b/tests/test_sensor_multi_leg.py
@@ -1,0 +1,183 @@
+"""Tests for per-leg sensors on multi-leg journey config entries."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.my_rail_commute.const import (
+    CONF_COMMUTE_NAME,
+    CONF_DESTINATION,
+    CONF_LEGS,
+    CONF_MAJOR_DELAY_THRESHOLD,
+    CONF_MINOR_DELAY_THRESHOLD,
+    CONF_NIGHT_UPDATES,
+    CONF_NUM_SERVICES,
+    CONF_ORIGIN,
+    CONF_SEVERE_DELAY_THRESHOLD,
+    CONF_TIME_WINDOW,
+    DEFAULT_MAJOR_DELAY_THRESHOLD,
+    DEFAULT_MINOR_DELAY_THRESHOLD,
+    DEFAULT_SEVERE_DELAY_THRESHOLD,
+    DOMAIN,
+)
+
+_TEST_TIME = datetime(2024, 1, 15, 8, 0, 0, tzinfo=dt_util.UTC)
+
+
+def _leg_response(origin_name: str, destination_name: str, service_id: str) -> dict:
+    return {
+        "location_name": origin_name,
+        "destination_name": destination_name,
+        "services": [
+            {
+                "scheduled_departure": "08:35",
+                "expected_departure": "08:35",
+                "platform": "3",
+                "operator": "Great Western Railway",
+                "service_id": service_id,
+                "calling_points": [destination_name],
+                "delay_minutes": 0,
+                "status": "on_time",
+                "is_cancelled": False,
+                "cancellation_reason": None,
+                "delay_reason": None,
+                "scheduled_arrival": "08:55",
+                "estimated_arrival": "08:55",
+                "destination": destination_name,
+            }
+        ],
+        "generated_at": "2024-01-15T08:30:00",
+        "nrcc_messages": [],
+    }
+
+
+@pytest.fixture(name="multi_leg_entry")
+def multi_leg_entry_fixture() -> MockConfigEntry:
+    """Return a mock multi-leg config entry (PAD -> RDG -> OXF)."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "test_api_key_12345",
+            CONF_ORIGIN: "PAD",
+            CONF_DESTINATION: "OXF",
+            CONF_LEGS: legs,
+            CONF_COMMUTE_NAME: "Test Journey",
+            CONF_TIME_WINDOW: 60,
+            CONF_NUM_SERVICES: 2,
+            CONF_NIGHT_UPDATES: True,
+            CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+            CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+            CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+        },
+        unique_id="PAD_RDG_OXF",
+    )
+
+
+async def test_multi_leg_entry_creates_per_leg_sensors(
+    hass: HomeAssistant, multi_leg_entry, mock_api_client
+) -> None:
+    """A multi-leg entry creates leg-scoped sensors instead of the flat train range."""
+    mock_api_client.get_departure_board = AsyncMock(
+        side_effect=[
+            _leg_response("Paddington", "Reading", "svc-leg1"),
+            _leg_response("Reading", "Oxford", "svc-leg2"),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        multi_leg_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(multi_leg_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Overall (combined) sensors still exist under the historical names
+    assert hass.states.get("sensor.test_journey_summary") is not None
+    assert hass.states.get("sensor.test_journey_status") is not None
+
+    # Per-leg sensors exist for both legs, using the new leg-scoped naming
+    leg1_train1 = hass.states.get("sensor.test_journey_leg_1_train_1")
+    leg2_train1 = hass.states.get("sensor.test_journey_leg_2_train_1")
+    assert leg1_train1 is not None
+    assert leg2_train1 is not None
+    assert leg1_train1.attributes["service_id"] == "svc-leg1"
+    assert leg2_train1.attributes["service_id"] == "svc-leg2"
+
+    assert hass.states.get("sensor.test_journey_leg_1_summary") is not None
+    assert hass.states.get("sensor.test_journey_leg_1_status") is not None
+    assert hass.states.get("sensor.test_journey_leg_1_next_train") is not None
+    assert hass.states.get("sensor.test_journey_leg_2_summary") is not None
+    assert hass.states.get("sensor.test_journey_leg_2_status") is not None
+    assert hass.states.get("sensor.test_journey_leg_2_next_train") is not None
+
+    # The flat single-leg sensors must NOT be created for a multi-leg entry
+    assert hass.states.get("sensor.test_journey_next_train") is None
+    assert hass.states.get("sensor.test_journey_train_1") is None
+
+
+async def test_multi_leg_overall_status_reflects_worst_leg(
+    hass: HomeAssistant, multi_leg_entry, mock_api_client
+) -> None:
+    """The combined Status sensor reflects the worst status across legs."""
+    delayed_leg2 = _leg_response("Reading", "Oxford", "svc-leg2")
+    delayed_leg2["services"][0]["expected_departure"] = "09:15"
+    delayed_leg2["services"][0]["delay_minutes"] = 20
+    delayed_leg2["services"][0]["status"] = "delayed"
+
+    mock_api_client.get_departure_board = AsyncMock(
+        side_effect=[
+            _leg_response("Paddington", "Reading", "svc-leg1"),
+            delayed_leg2,
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        multi_leg_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(multi_leg_entry.entry_id)
+        await hass.async_block_till_done()
+
+    overall_status = hass.states.get("sensor.test_journey_status")
+    leg1_status = hass.states.get("sensor.test_journey_leg_1_status")
+    leg2_status = hass.states.get("sensor.test_journey_leg_2_status")
+
+    assert leg1_status.state == "Normal"
+    assert leg2_status.state == "Severe Disruption"
+    assert overall_status.state == "Severe Disruption"
+
+
+async def test_multi_leg_device_id_uses_full_chain(
+    hass: HomeAssistant, multi_leg_entry, mock_api_client
+) -> None:
+    """The device identifier embeds the full station chain, not just endpoints."""
+    from homeassistant.helpers import device_registry as dr
+
+    mock_api_client.get_departure_board = AsyncMock(
+        side_effect=[
+            _leg_response("Paddington", "Reading", "svc-leg1"),
+            _leg_response("Reading", "Oxford", "svc-leg2"),
+        ]
+    )
+
+    multi_leg_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(multi_leg_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_reg = dr.async_get(hass)
+    device = device_reg.async_get_device(identifiers={(DOMAIN, "PAD_RDG_OXF")})
+    assert device is not None
+    assert device.name == "Test Journey"

--- a/tests/test_sensor_platform_changes.py
+++ b/tests/test_sensor_platform_changes.py
@@ -102,6 +102,7 @@ def test_platform_change_detection_unit():
     """Unit test for platform change detection logic."""
     # Create a mock coordinator
     mock_coordinator = MagicMock()
+    mock_coordinator.legs = [{"origin": "PAD", "destination": "RDG"}]
     mock_entry = MagicMock()
     mock_entry.entry_id = "test_entry"
 
@@ -181,6 +182,7 @@ def test_platform_change_from_tba_unit():
     """Unit test for platform assignment from TBA."""
     # Create a mock coordinator
     mock_coordinator = MagicMock()
+    mock_coordinator.legs = [{"origin": "PAD", "destination": "RDG"}]
     mock_entry = MagicMock()
     mock_entry.entry_id = "test_entry"
 
@@ -228,6 +230,7 @@ def test_platform_change_no_service_id():
     """Unit test for handling missing/invalid service_id."""
     # Create a mock coordinator
     mock_coordinator = MagicMock()
+    mock_coordinator.legs = [{"origin": "PAD", "destination": "RDG"}]
     mock_entry = MagicMock()
     mock_entry.entry_id = "test_entry"
 
@@ -294,6 +297,7 @@ def test_platform_no_change_same_service():
     """Unit test for no platform change with same service."""
     # Create a mock coordinator
     mock_coordinator = MagicMock()
+    mock_coordinator.legs = [{"origin": "PAD", "destination": "RDG"}]
     mock_entry = MagicMock()
     mock_entry.entry_id = "test_entry"
 

--- a/tests/test_sensor_summary_stats.py
+++ b/tests/test_sensor_summary_stats.py
@@ -32,6 +32,7 @@ def _make_coordinator(origin="LBG", destination="WYT", stats_store=None):
     coordinator = MagicMock(spec=NationalRailDataUpdateCoordinator)
     coordinator.origin = origin
     coordinator.destination = destination
+    coordinator.legs = [{"origin": origin, "destination": destination}]
     coordinator.num_services = 3
     coordinator.stats_store = stats_store
     coordinator.data = {


### PR DESCRIPTION
Journeys that require changing trains (e.g. Home -> Interchange -> Work) can
now be configured as a sequence of legs during setup. The coordinator fetches
each leg sequentially and rolls per-leg statuses up into an overall worst-case
journey status, exposed via new per-leg sensors alongside the existing
combined Summary/Status/Historical sensors. Single-leg entries are completely
unaffected: CONF_LEGS is only persisted for journeys with more than one leg,
and the route/device identifier scheme is a strict generalisation of the
historical format. The "Add return journey" toggle now reverses the full leg
sequence (both order and direction) instead of just the overall endpoints.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Pr2j4tTWxZ3RbkHv946MA