### PR TITLE
Fix multi-leg config flow inserting connecting legs after destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,9 @@ To track multiple routes:
 
 Many commutes require a change of train partway through (e.g. Home → Interchange, then a different service Interchange → Work). To set one up:
 
-1. During setup, configure your first leg (origin → destination) as usual
-2. When asked "Add a connecting leg?", choose yes and enter the next destination — the new leg's origin is automatically the station you just alighted at
-3. Repeat for as many changes as your journey needs, then decline to finish the itinerary
+1. During setup, configure your Origin and final Destination as usual (e.g. Home → Work) — these stay fixed as the journey's overall endpoints
+2. When asked "Add a connecting leg?", choose yes and enter the station where you change trains (e.g. Interchange) — it's inserted between the last confirmed point and your final destination
+3. Repeat for as many changes as your journey needs, then decline once you can travel straight through to your destination
 4. Continue through the settings step as normal (time window, number of services tracked, and delay thresholds apply to every leg)
 
 A multi-leg journey creates one device with sensors per leg instead of the flat train list:

--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -200,6 +200,8 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._nearby_stations: list[tuple[float, dict]] | None = None
         self._legs: list[dict[str, Any]] = []
         self._leg_names: list[dict[str, str]] = []
+        self._current_point: str | None = None
+        self._current_point_name: str | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -331,6 +333,8 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._leg_names = [
                         {"origin_name": self._origin_name, "destination_name": None}
                     ]
+                    self._current_point = None
+                    self._current_point_name = None
                 else:
                     destination = user_input.get(CONF_DESTINATION, "").strip()
                     if not destination:
@@ -347,13 +351,12 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._origin_name = station_info["origin_name"]
                     self._destination_name = station_info["destination_name"]
                     self._all_departures = False
-                    self._legs = [{"origin": self._origin, "destination": self._destination}]
-                    self._leg_names = [
-                        {
-                            "origin_name": self._origin_name,
-                            "destination_name": self._destination_name,
-                        }
-                    ]
+                    # The itinerary is built up as connecting legs are added below;
+                    # origin and destination stay fixed as the journey's endpoints.
+                    self._legs = []
+                    self._leg_names = []
+                    self._current_point = self._origin
+                    self._current_point_name = self._origin_name
 
                 if self._all_departures:
                     return await self.async_step_settings()
@@ -409,10 +412,12 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_add_leg(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Offer to add a connecting leg (a change of train) to the journey.
+        """Offer to insert a connecting leg (a change of train) into the journey.
 
-        Loops until the user declines: each accepted leg's origin is the
-        previous leg's destination (where you alight and change trains).
+        The origin and destination chosen in the stations step stay fixed as
+        the journey's endpoints. Each accepted station here is inserted as an
+        interchange between the last confirmed point and that destination.
+        Declining closes the itinerary with a final leg to the destination.
 
         Args:
             user_input: User input data
@@ -424,21 +429,31 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if not user_input.get(CONF_ADD_LEG, False):
+                # Close the chain with a final leg from the last confirmed
+                # point (origin, if no interchanges were inserted) to the
+                # fixed destination.
+                self._legs.append(
+                    {"origin": self._current_point, "destination": self._destination}
+                )
                 return await self.async_step_settings()
 
             try:
-                new_destination = user_input.get(CONF_LEG_DESTINATION, "").strip()
-                if not new_destination:
+                new_station = user_input.get(CONF_LEG_DESTINATION, "").strip()
+                if not new_station:
                     errors[CONF_LEG_DESTINATION] = "required"
                     raise ValueError("destination_required")
 
+                if new_station.strip().upper() == self._destination:
+                    errors[CONF_LEG_DESTINATION] = "same_as_destination"
+                    raise ValueError("same_as_destination")
+
                 station_info = await validate_stations(
-                    self.hass, self._api_key, self._destination, new_destination
+                    self.hass, self._api_key, self._current_point, new_station
                 )
 
-                new_destination = new_destination.upper()
+                new_station = new_station.upper()
                 self._legs.append(
-                    {"origin": self._destination, "destination": new_destination}
+                    {"origin": self._current_point, "destination": new_station}
                 )
                 self._leg_names.append(
                     {
@@ -446,14 +461,14 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "destination_name": station_info["destination_name"],
                     }
                 )
-                self._destination = new_destination
-                self._destination_name = station_info["destination_name"]
+                self._current_point = new_station
+                self._current_point_name = station_info["destination_name"]
 
                 # Loop back to offer another leg
                 return await self.async_step_add_leg()
 
             except ValueError as err:
-                if "destination_required" not in str(err):
+                if "destination_required" not in str(err) and "same_as_destination" not in str(err):
                     errors["base"] = "same_station"
             except InvalidStationError:
                 errors["base"] = "invalid_station"
@@ -466,8 +481,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
 
         itinerary = " → ".join(
-            [self._leg_names[0]["origin_name"]]
-            + [n["destination_name"] for n in self._leg_names]
+            [self._origin_name] + [n["destination_name"] for n in self._leg_names]
         )
 
         return self.async_show_form(
@@ -481,6 +495,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={
                 "itinerary": itinerary,
+                "current_point": self._current_point_name,
                 "destination": self._destination_name,
             },
         )

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -10,7 +10,7 @@
       },
       "stations": {
         "title": "Configure Route",
-        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enable 'All Departures' to show every train from this station, or enter a destination CRS code to track a specific route.",
+        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enable 'All Departures' to show every train from this station, or enter your final destination CRS code to track a specific route. If your journey needs a change of train, you'll be able to add the interchange station(s) next — Origin and Destination here stay fixed as your journey's overall start and end.",
         "data": {
           "origin": "Origin Station",
           "all_departures": "Show All Departures (no destination filter)",
@@ -19,10 +19,10 @@
       },
       "add_leg": {
         "title": "Add a Connecting Leg",
-        "description": "Your journey so far: {itinerary}\n\nDoes this journey require a change of train? Add a connecting leg departing from {destination}, or continue if your itinerary is complete.",
+        "description": "Your journey so far: {itinerary}, travelling to {destination}.\n\nDo you need to change trains somewhere between {current_point} and {destination}? Enter that interchange station, or continue if you travel straight through.",
         "data": {
           "add_leg": "Add a connecting leg",
-          "leg_destination": "Next Destination Station (CRS Code)"
+          "leg_destination": "Change At Station (CRS Code)"
         }
       },
       "settings": {
@@ -52,6 +52,7 @@
       "cannot_connect": "Unable to connect to Rail API. Please try again later.",
       "invalid_station": "Invalid station code. Please use a valid 3-letter CRS code.",
       "same_station": "Origin and destination stations must be different.",
+      "same_as_destination": "This is already your final destination — continue instead of adding it as a connecting leg.",
       "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute.",
       "unknown": "An unexpected error occurred. Please try again."
     },

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -10,7 +10,7 @@
       },
       "stations": {
         "title": "Configure Route",
-        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enable 'All Departures' to show every train from this station, or enter a destination CRS code to track a specific route.",
+        "description": "Select your origin station from the nearby stations list, or type a 3-letter CRS code directly (e.g., PAD for Paddington). Enable 'All Departures' to show every train from this station, or enter your final destination CRS code to track a specific route. If your journey needs a change of train, you'll be able to add the interchange station(s) next — Origin and Destination here stay fixed as your journey's overall start and end.",
         "data": {
           "origin": "Origin Station",
           "all_departures": "Show All Departures (no destination filter)",
@@ -19,10 +19,10 @@
       },
       "add_leg": {
         "title": "Add a Connecting Leg",
-        "description": "Your journey so far: {itinerary}\n\nDoes this journey require a change of train? Add a connecting leg departing from {destination}, or continue if your itinerary is complete.",
+        "description": "Your journey so far: {itinerary}, travelling to {destination}.\n\nDo you need to change trains somewhere between {current_point} and {destination}? Enter that interchange station, or continue if you travel straight through.",
         "data": {
           "add_leg": "Add a connecting leg",
-          "leg_destination": "Next Destination Station (CRS Code)"
+          "leg_destination": "Change At Station (CRS Code)"
         }
       },
       "settings": {
@@ -52,6 +52,7 @@
       "cannot_connect": "Unable to connect to Rail API. Please try again later.",
       "invalid_station": "Invalid station code. Please use a valid 3-letter CRS code.",
       "same_station": "Origin and destination stations must be different.",
+      "same_as_destination": "This is already your final destination — continue instead of adding it as a connecting leg.",
       "invalid_thresholds": "Delay thresholds must maintain hierarchy: Severe >= Major >= Minor >= 1 minute.",
       "unknown": "An unexpected error occurred. Please try again."
     },

--- a/tests/test_config_flow_multi_leg.py
+++ b/tests/test_config_flow_multi_leg.py
@@ -98,43 +98,47 @@ class TestAddLegStep:
         assert result["data"][CONF_ORIGIN] == "PAD"
         assert result["data"][CONF_DESTINATION] == "RDG"
 
-    async def test_adding_two_legs_persists_full_chain(self, hass: HomeAssistant):
-        """Accepting add_leg twice then declining persists a 3-leg CONF_LEGS list."""
+    async def test_adding_two_legs_inserts_interchanges_before_destination(
+        self, hass: HomeAssistant
+    ):
+        """Accepting add_leg twice then declining inserts interchanges before
+        the fixed destination chosen in the stations step, rather than
+        appending stations past it."""
         result = await _start_flow(hass)
 
         with patch(
             "custom_components.my_rail_commute.config_flow.validate_stations",
             return_value={
                 "origin_name": "London Paddington",
-                "destination_name": "Reading",
+                "destination_name": "Birmingham New Street",
             },
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
-                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "BHM"},
             )
         assert result["step_id"] == "add_leg"
 
         with patch(
             "custom_components.my_rail_commute.config_flow.validate_stations",
-            return_value={"origin_name": "Reading", "destination_name": "Oxford"},
+            return_value={"origin_name": "London Paddington", "destination_name": "Reading"},
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
-                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "OXF"},
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "RDG"},
             )
         assert result["step_id"] == "add_leg"
 
         with patch(
             "custom_components.my_rail_commute.config_flow.validate_stations",
             return_value={
-                "origin_name": "Oxford",
-                "destination_name": "Birmingham New Street",
+                "origin_name": "Reading",
+                "destination_name": "Oxford",
             },
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
-                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "BHM"},
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "OXF"},
             )
         assert result["step_id"] == "add_leg"
 
@@ -156,12 +160,42 @@ class TestAddLegStep:
             {"origin": "RDG", "destination": "OXF"},
             {"origin": "OXF", "destination": "BHM"},
         ]
-        # Convenience flat origin/destination reflect the whole chain's endpoints
+        # The originally configured origin/destination stay fixed as the
+        # journey's overall endpoints, regardless of how many interchanges
+        # were inserted between them.
         assert result["data"][CONF_ORIGIN] == "PAD"
         assert result["data"][CONF_DESTINATION] == "BHM"
 
+    async def test_add_leg_rejects_final_destination_as_interchange(
+        self, hass: HomeAssistant
+    ):
+        """Entering the fixed final destination as a connecting leg errors."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "RDG"},
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "add_leg"
+        assert result["errors"] == {CONF_LEG_DESTINATION: "same_as_destination"}
+
     async def test_unique_id_is_chain_based_for_multi_leg(self, hass: HomeAssistant):
-        """The config entry's unique_id embeds every station in the chain."""
+        """The config entry's unique_id embeds every station in the chain,
+        with the inserted interchange ordered before the fixed destination."""
         result = await _start_flow(hass)
 
         with patch(
@@ -178,7 +212,7 @@ class TestAddLegStep:
 
         with patch(
             "custom_components.my_rail_commute.config_flow.validate_stations",
-            return_value={"origin_name": "Reading", "destination_name": "Oxford"},
+            return_value={"origin_name": "London Paddington", "destination_name": "Oxford"},
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
@@ -195,7 +229,7 @@ class TestAddLegStep:
 
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
-        assert entries[0].unique_id == "PAD_RDG_OXF"
+        assert entries[0].unique_id == "PAD_OXF_RDG"
 
     async def test_add_leg_same_station_shows_error(self, hass: HomeAssistant):
         """Requesting a leg destination identical to the current station errors."""
@@ -219,7 +253,7 @@ class TestAddLegStep:
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
-                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "RDG"},
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "PAD"},
             )
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
@@ -273,7 +307,7 @@ class TestMultiLegReturnJourney:
 
         with patch(
             "custom_components.my_rail_commute.config_flow.validate_stations",
-            return_value={"origin_name": "Reading", "destination_name": "Oxford"},
+            return_value={"origin_name": "London Paddington", "destination_name": "Oxford"},
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
@@ -300,15 +334,17 @@ class TestMultiLegReturnJourney:
         assert mock_init.call_count == 1
         reverse_data = mock_init.call_args.kwargs["data"]
 
+        # Original chain is PAD -> OXF -> RDG (OXF inserted before the fixed
+        # destination); the reverse route flips both order and direction.
         assert reverse_data[CONF_LEGS] == [
-            {"origin": "OXF", "destination": "RDG"},
-            {"origin": "RDG", "destination": "PAD"},
+            {"origin": "RDG", "destination": "OXF"},
+            {"origin": "OXF", "destination": "PAD"},
         ]
-        assert reverse_data[CONF_ORIGIN] == "OXF"
+        assert reverse_data[CONF_ORIGIN] == "RDG"
         assert reverse_data[CONF_DESTINATION] == "PAD"
 
         # The reverse import flow itself must persist CONF_LEGS and use a
         # chain-based unique_id, not just the overall origin/destination
         entries = hass.config_entries.async_entries(DOMAIN)
-        reverse_entry = next(e for e in entries if e.unique_id == "OXF_RDG_PAD")
+        reverse_entry = next(e for e in entries if e.unique_id == "RDG_OXF_PAD")
         assert reverse_entry.data[CONF_LEGS] == reverse_data[CONF_LEGS]


### PR DESCRIPTION
## Summary
- Fixes a bug where adding a connecting leg during multi-leg setup appended the new station *after* the configured destination instead of inserting it *between* Origin and Destination (e.g. Origin=Whyteleafe, Destination=Bromley South, adding "London Bridge" produced Whyteleafe → Bromley South → London Bridge instead of Whyteleafe → London Bridge → Bromley South).
- Origin and Destination chosen in the stations step now stay fixed as the journey's overall endpoints; each accepted connecting leg is inserted between the last confirmed point and that destination, and declining closes the itinerary with a final leg into the destination.
- Added a guard against entering the final destination itself as an interchange, and clarified the config flow wording/translations and README instructions describing multi-leg setup.

## Test plan
- [x] `uv run pytest tests/` — all 149 tests pass (updated `tests/test_config_flow_multi_leg.py` to cover the corrected leg-insertion order, unique-id generation, and return-journey reversal)
- [x] `uv run ruff check` on changed files
- [x] Verified JSON validity of `strings.json` and `translations/en.json`

**Note:** Existing config entries created before this fix will need to be removed and reconfigured to get the corrected station order.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6kqtx7BhLAxfys7qegRGB)_