### PR TITLE
Make multi-leg overall status connection-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,11 +277,12 @@ Many commutes require a change of train partway through (e.g. Home → Interchan
 1. During setup, configure your Origin and final Destination as usual (e.g. Home → Work) — these stay fixed as the journey's overall endpoints
 2. When asked "Add a connecting leg?", choose yes and enter the station where you change trains (e.g. Interchange) — it's inserted between the last confirmed point and your final destination
 3. Repeat for as many changes as your journey needs, then decline once you can travel straight through to your destination
-4. Continue through the settings step as normal (time window, number of services tracked, and delay thresholds apply to every leg)
+4. Continue through the settings step as normal (time window, number of services tracked, and delay thresholds apply to every leg). For multi-leg journeys you'll also be asked for a **Minimum Connection Time** (default 5 minutes) — the buffer needed to make each change
 
 A multi-leg journey creates one device with sensors per leg instead of the flat train list:
 - `sensor.{commute_name}_leg{n}_summary`, `_status`, `_next_train`, and `_train_{m}` for each leg `n`
-- The top-level `Summary`/`Status` sensors (and the `Has Disruption` binary sensor) reflect the **whole journey**: worst-case status across all legs, and combined service counts
+- `sensor.{commute_name}_connection{n}_status` for each interchange, reporting whether that change is actually achievable given the current expected times: **Connection OK**, **Tight Connection** (feasible but under a comfortable margin), **Delayed Connection** (you'll miss the planned train but a later one still works), or **Missed Connection** (no tracked service leaves in time). Attributes include the interchange station, arrival/departure times, buffer in minutes, and the connecting service actually matched
+- The top-level `Summary`/`Status` sensors (and the `Has Disruption` binary sensor) reflect the **whole journey**: the worst case across all legs *and* all connections — so a missed connection pushes the overall status to Critical even if every individual leg is otherwise on time. The `Summary` sensor also exposes `connections` (the full per-connection detail) and `journey_feasible` (false if any connection is missed)
 
 **Note**: Historical Reliability/Delays sensors report on-time percentage and average delay for the **combined whole journey**, not broken down by individual leg.
 

--- a/custom_components/my_rail_commute/binary_sensor.py
+++ b/custom_components/my_rail_commute/binary_sensor.py
@@ -15,6 +15,7 @@ from .const import (
     ATTR_CANCELLED_COUNT,
     ATTR_DELAYED_COUNT,
     ATTR_DISRUPTION_REASONS,
+    ATTR_JOURNEY_FEASIBLE,
     ATTR_MAX_DELAY,
     CONF_COMMUTE_NAME,
     DOMAIN,
@@ -157,6 +158,9 @@ class DisruptionSensor(NationalRailCommuteBinarySensor):
             ATTR_DISRUPTION_REASONS: data.get("disruption_reasons", []),
             "last_checked": data.get("last_updated"),
         }
+
+        if data.get("is_multi_leg"):
+            attributes[ATTR_JOURNEY_FEASIBLE] = data.get("journey_feasible")
 
         return attributes
 

--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_LEG_DESTINATION,
     CONF_LEGS,
     CONF_MAJOR_DELAY_THRESHOLD,
+    CONF_MIN_CONNECTION_TIME,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
     CONF_NUM_SERVICES,
@@ -41,6 +42,7 @@ from .const import (
     CONF_TIME_WINDOW,
     DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
     DEFAULT_MAJOR_DELAY_THRESHOLD,
+    DEFAULT_MIN_CONNECTION_TIME,
     DEFAULT_MINOR_DELAY_THRESHOLD,
     DEFAULT_NAME,
     DEFAULT_NIGHT_UPDATES,
@@ -50,10 +52,12 @@ from .const import (
     DOMAIN,
     LOCATION_SEARCH_MAX_RADIUS_MILES,
     LOCATION_SEARCH_MIN_RADIUS_MILES,
+    MAX_CONNECTION_TIME,
     MAX_DELAY_THRESHOLD,
     MAX_GRACE_PERIOD,
     MAX_NUM_SERVICES,
     MAX_TIME_WINDOW,
+    MIN_CONNECTION_TIME,
     MIN_DELAY_THRESHOLD,
     MIN_GRACE_PERIOD,
     MIN_NUM_SERVICES,
@@ -197,6 +201,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._major_delay_threshold: int | None = None
         self._minor_delay_threshold: int | None = None
         self._departed_train_grace_period: int | None = None
+        self._min_connection_time: int | None = None
         self._nearby_stations: list[tuple[float, dict]] | None = None
         self._legs: list[dict[str, Any]] = []
         self._leg_names: list[dict[str, str]] = []
@@ -541,6 +546,10 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._departed_train_grace_period = user_input.get(
                     CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD
                 )
+                if len(self._legs) > 1:
+                    self._min_connection_time = user_input.get(
+                        CONF_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME
+                    )
 
                 # Set unique ID based on the full route chain (all-departures
                 # gets a distinct suffix; single-leg routes match the historical format)
@@ -559,89 +568,105 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             default_name = f"{self._origin_name} to {self._destination_name}"
 
-        data_schema = vol.Schema(
-            {
-                vol.Optional(
-                    CONF_COMMUTE_NAME,
-                    default=default_name,
-                ): str,
-                vol.Required(
-                    CONF_TIME_WINDOW,
-                    default=DEFAULT_TIME_WINDOW,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_TIME_WINDOW,
-                        max=MAX_TIME_WINDOW,
-                        step=5,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+        schema_dict: dict[Any, Any] = {
+            vol.Optional(
+                CONF_COMMUTE_NAME,
+                default=default_name,
+            ): str,
+            vol.Required(
+                CONF_TIME_WINDOW,
+                default=DEFAULT_TIME_WINDOW,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_TIME_WINDOW,
+                    max=MAX_TIME_WINDOW,
+                    step=5,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
                 ),
-                vol.Required(
-                    CONF_NUM_SERVICES,
-                    default=DEFAULT_NUM_SERVICES,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_NUM_SERVICES,
-                        max=MAX_NUM_SERVICES,
-                        step=1,
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+            ),
+            vol.Required(
+                CONF_NUM_SERVICES,
+                default=DEFAULT_NUM_SERVICES,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_NUM_SERVICES,
+                    max=MAX_NUM_SERVICES,
+                    step=1,
+                    mode=selector.NumberSelectorMode.SLIDER,
                 ),
-                vol.Required(
-                    CONF_SEVERE_DELAY_THRESHOLD,
-                    default=DEFAULT_SEVERE_DELAY_THRESHOLD,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_DELAY_THRESHOLD,
-                        max=MAX_DELAY_THRESHOLD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+            ),
+            vol.Required(
+                CONF_SEVERE_DELAY_THRESHOLD,
+                default=DEFAULT_SEVERE_DELAY_THRESHOLD,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_DELAY_THRESHOLD,
+                    max=MAX_DELAY_THRESHOLD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
                 ),
-                vol.Required(
-                    CONF_MAJOR_DELAY_THRESHOLD,
-                    default=DEFAULT_MAJOR_DELAY_THRESHOLD,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_DELAY_THRESHOLD,
-                        max=MAX_DELAY_THRESHOLD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+            ),
+            vol.Required(
+                CONF_MAJOR_DELAY_THRESHOLD,
+                default=DEFAULT_MAJOR_DELAY_THRESHOLD,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_DELAY_THRESHOLD,
+                    max=MAX_DELAY_THRESHOLD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
                 ),
-                vol.Required(
-                    CONF_MINOR_DELAY_THRESHOLD,
-                    default=DEFAULT_MINOR_DELAY_THRESHOLD,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_DELAY_THRESHOLD,
-                        max=MAX_DELAY_THRESHOLD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+            ),
+            vol.Required(
+                CONF_MINOR_DELAY_THRESHOLD,
+                default=DEFAULT_MINOR_DELAY_THRESHOLD,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_DELAY_THRESHOLD,
+                    max=MAX_DELAY_THRESHOLD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
                 ),
-                vol.Required(
-                    CONF_NIGHT_UPDATES,
-                    default=DEFAULT_NIGHT_UPDATES,
-                ): selector.BooleanSelector(),
-                vol.Required(
-                    CONF_DEPARTED_TRAIN_GRACE_PERIOD,
-                    default=DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_GRACE_PERIOD,
-                        max=MAX_GRACE_PERIOD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+            ),
+            vol.Required(
+                CONF_NIGHT_UPDATES,
+                default=DEFAULT_NIGHT_UPDATES,
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_DEPARTED_TRAIN_GRACE_PERIOD,
+                default=DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_GRACE_PERIOD,
+                    max=MAX_GRACE_PERIOD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
                 ),
-            }
-        )
+            ),
+        }
+
+        if len(self._legs) > 1:
+            schema_dict[
+                vol.Required(
+                    CONF_MIN_CONNECTION_TIME,
+                    default=DEFAULT_MIN_CONNECTION_TIME,
+                )
+            ] = selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_CONNECTION_TIME,
+                    max=MAX_CONNECTION_TIME,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
+                ),
+            )
+
+        data_schema = vol.Schema(schema_dict)
 
         return self.async_show_form(
             step_id="settings",
@@ -696,6 +721,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
                 if len(self._legs) > 1:
                     reverse_data[CONF_LEGS] = reversed_legs
+                    reverse_data[CONF_MIN_CONNECTION_TIME] = (
+                        self._min_connection_time or DEFAULT_MIN_CONNECTION_TIME
+                    )
 
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_init(
@@ -764,6 +792,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data[CONF_LEGS] = self._legs
             data[CONF_ORIGIN] = self._legs[0]["origin"]
             data[CONF_DESTINATION] = self._legs[-1]["destination"]
+            data[CONF_MIN_CONNECTION_TIME] = (
+                self._min_connection_time or DEFAULT_MIN_CONNECTION_TIME
+            )
         return self.async_create_entry(title=self._commute_name, data=data)
 
     @staticmethod
@@ -819,114 +850,135 @@ class NationalRailCommuteOptionsFlow(config_entries.OptionsFlow):
                 # Update the config entry
                 return self.async_create_entry(title="", data=data)
 
-        data_schema = vol.Schema(
-            {
-                vol.Required(
+        schema_dict: dict[Any, Any] = {
+            vol.Required(
+                CONF_TIME_WINDOW,
+                default=options.get(
                     CONF_TIME_WINDOW,
-                    default=options.get(
-                        CONF_TIME_WINDOW,
-                        current_data.get(CONF_TIME_WINDOW, DEFAULT_TIME_WINDOW),
-                    ),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_TIME_WINDOW,
-                        max=MAX_TIME_WINDOW,
-                        step=5,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+                    current_data.get(CONF_TIME_WINDOW, DEFAULT_TIME_WINDOW),
                 ),
-                vol.Required(
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_TIME_WINDOW,
+                    max=MAX_TIME_WINDOW,
+                    step=5,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
+                ),
+            ),
+            vol.Required(
+                CONF_NUM_SERVICES,
+                default=options.get(
                     CONF_NUM_SERVICES,
-                    default=options.get(
-                        CONF_NUM_SERVICES,
-                        current_data.get(CONF_NUM_SERVICES, DEFAULT_NUM_SERVICES),
-                    ),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_NUM_SERVICES,
-                        max=MAX_NUM_SERVICES,
-                        step=1,
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+                    current_data.get(CONF_NUM_SERVICES, DEFAULT_NUM_SERVICES),
                 ),
-                vol.Required(
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_NUM_SERVICES,
+                    max=MAX_NUM_SERVICES,
+                    step=1,
+                    mode=selector.NumberSelectorMode.SLIDER,
+                ),
+            ),
+            vol.Required(
+                CONF_SEVERE_DELAY_THRESHOLD,
+                default=options.get(
                     CONF_SEVERE_DELAY_THRESHOLD,
-                    default=options.get(
+                    current_data.get(
                         CONF_SEVERE_DELAY_THRESHOLD,
-                        current_data.get(
-                            CONF_SEVERE_DELAY_THRESHOLD,
-                            # Migration from old config
-                            current_data.get(CONF_DISRUPTION_SINGLE_DELAY, DEFAULT_SEVERE_DELAY_THRESHOLD),
-                        ),
-                    ),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_DELAY_THRESHOLD,
-                        max=MAX_DELAY_THRESHOLD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
+                        # Migration from old config
+                        current_data.get(CONF_DISRUPTION_SINGLE_DELAY, DEFAULT_SEVERE_DELAY_THRESHOLD),
                     ),
                 ),
-                vol.Required(
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_DELAY_THRESHOLD,
+                    max=MAX_DELAY_THRESHOLD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
+                ),
+            ),
+            vol.Required(
+                CONF_MAJOR_DELAY_THRESHOLD,
+                default=options.get(
                     CONF_MAJOR_DELAY_THRESHOLD,
-                    default=options.get(
+                    current_data.get(
                         CONF_MAJOR_DELAY_THRESHOLD,
+                        # Migration from old config
+                        current_data.get(CONF_DISRUPTION_MULTIPLE_DELAY, DEFAULT_MAJOR_DELAY_THRESHOLD),
+                    ),
+                ),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_DELAY_THRESHOLD,
+                    max=MAX_DELAY_THRESHOLD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
+                ),
+            ),
+            vol.Required(
+                CONF_MINOR_DELAY_THRESHOLD,
+                default=options.get(
+                    CONF_MINOR_DELAY_THRESHOLD,
+                    current_data.get(CONF_MINOR_DELAY_THRESHOLD, DEFAULT_MINOR_DELAY_THRESHOLD),
+                ),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_DELAY_THRESHOLD,
+                    max=MAX_DELAY_THRESHOLD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
+                ),
+            ),
+            vol.Required(
+                CONF_NIGHT_UPDATES,
+                default=options.get(
+                    CONF_NIGHT_UPDATES,
+                    current_data.get(CONF_NIGHT_UPDATES, DEFAULT_NIGHT_UPDATES),
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_DEPARTED_TRAIN_GRACE_PERIOD,
+                default=options.get(
+                    CONF_DEPARTED_TRAIN_GRACE_PERIOD,
+                    current_data.get(CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD),
+                ),
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_GRACE_PERIOD,
+                    max=MAX_GRACE_PERIOD,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
+                ),
+            ),
+        }
+
+        if len(current_data.get(CONF_LEGS) or []) > 1:
+            schema_dict[
+                vol.Required(
+                    CONF_MIN_CONNECTION_TIME,
+                    default=options.get(
+                        CONF_MIN_CONNECTION_TIME,
                         current_data.get(
-                            CONF_MAJOR_DELAY_THRESHOLD,
-                            # Migration from old config
-                            current_data.get(CONF_DISRUPTION_MULTIPLE_DELAY, DEFAULT_MAJOR_DELAY_THRESHOLD),
+                            CONF_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME
                         ),
                     ),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_DELAY_THRESHOLD,
-                        max=MAX_DELAY_THRESHOLD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
+                )
+            ] = selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MIN_CONNECTION_TIME,
+                    max=MAX_CONNECTION_TIME,
+                    step=1,
+                    unit_of_measurement="minutes",
+                    mode=selector.NumberSelectorMode.SLIDER,
                 ),
-                vol.Required(
-                    CONF_MINOR_DELAY_THRESHOLD,
-                    default=options.get(
-                        CONF_MINOR_DELAY_THRESHOLD,
-                        current_data.get(CONF_MINOR_DELAY_THRESHOLD, DEFAULT_MINOR_DELAY_THRESHOLD),
-                    ),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_DELAY_THRESHOLD,
-                        max=MAX_DELAY_THRESHOLD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
-                ),
-                vol.Required(
-                    CONF_NIGHT_UPDATES,
-                    default=options.get(
-                        CONF_NIGHT_UPDATES,
-                        current_data.get(CONF_NIGHT_UPDATES, DEFAULT_NIGHT_UPDATES),
-                    ),
-                ): selector.BooleanSelector(),
-                vol.Required(
-                    CONF_DEPARTED_TRAIN_GRACE_PERIOD,
-                    default=options.get(
-                        CONF_DEPARTED_TRAIN_GRACE_PERIOD,
-                        current_data.get(CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD),
-                    ),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MIN_GRACE_PERIOD,
-                        max=MAX_GRACE_PERIOD,
-                        step=1,
-                        unit_of_measurement="minutes",
-                        mode=selector.NumberSelectorMode.SLIDER,
-                    ),
-                ),
-            }
-        )
+            )
+
+        data_schema = vol.Schema(schema_dict)
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -22,6 +22,7 @@ CONF_ALL_DEPARTURES: Final = "all_departures"
 CONF_LEGS: Final = "legs"
 CONF_ADD_LEG: Final = "add_leg"
 CONF_LEG_DESTINATION: Final = "leg_destination"
+CONF_MIN_CONNECTION_TIME: Final = "min_connection_time"
 
 # Legacy config keys (for migration)
 CONF_DISRUPTION_SINGLE_DELAY: Final = "disruption_single_delay"
@@ -40,6 +41,7 @@ DEFAULT_NUM_SERVICES: Final = 3
 DEFAULT_NIGHT_UPDATES: Final = False
 DEFAULT_NAME: Final = "My Rail Commute"
 DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD: Final = 5  # minutes
+DEFAULT_MIN_CONNECTION_TIME: Final = 5  # minutes
 
 # Limits
 MIN_TIME_WINDOW: Final = 15
@@ -48,6 +50,12 @@ MIN_NUM_SERVICES: Final = 1
 MAX_NUM_SERVICES: Final = 10
 MIN_GRACE_PERIOD: Final = 0  # minutes
 MAX_GRACE_PERIOD: Final = 15  # minutes
+MIN_CONNECTION_TIME: Final = 0  # minutes
+MAX_CONNECTION_TIME: Final = 30  # minutes
+
+# Additional buffer above min_connection_time that still counts as "comfortable"
+# rather than "tight" for a connection that's otherwise on the planned train
+TIGHT_CONNECTION_MARGIN: Final = 5  # minutes
 
 # Location-based station lookup radius (miles)
 LOCATION_SEARCH_MIN_RADIUS_MILES: Final = 5.0
@@ -98,6 +106,16 @@ STATUS_MAJOR_DELAYS: Final = "Major Delays"
 STATUS_SEVERE_DISRUPTION: Final = "Severe Disruption"
 STATUS_CRITICAL: Final = "Critical"
 
+# Per-connection (interchange) feasibility statuses for multi-leg journeys.
+# These describe whether the next train on the outgoing leg is catchable
+# given the incoming leg's expected arrival, and are mapped onto the
+# STATUS_* hierarchy above when combined into the journey's overall_status.
+STATUS_CONNECTION_OK: Final = "Connection OK"
+STATUS_CONNECTION_TIGHT: Final = "Tight Connection"
+STATUS_CONNECTION_DELAYED: Final = "Delayed Connection"
+STATUS_CONNECTION_MISSED: Final = "Missed Connection"
+STATUS_CONNECTION_UNKNOWN: Final = "Unknown"
+
 # Attributes
 ATTR_ORIGIN: Final = "origin"
 ATTR_ORIGIN_NAME: Final = "origin_name"
@@ -128,6 +146,8 @@ ATTR_MAX_DELAY: Final = "max_delay_minutes"
 ATTR_DISRUPTION_REASONS: Final = "disruption_reasons"
 ATTR_LEGS: Final = "legs"
 ATTR_IS_MULTI_LEG: Final = "is_multi_leg"
+ATTR_CONNECTIONS: Final = "connections"
+ATTR_JOURNEY_FEASIBLE: Final = "journey_feasible"
 
 # API Error Messages
 ERROR_AUTH: Final = "Authentication failed. Please check your API key."

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_DISRUPTION_SINGLE_DELAY,
     CONF_LEGS,
     CONF_MAJOR_DELAY_THRESHOLD,
+    CONF_MIN_CONNECTION_TIME,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
     CONF_NUM_SERVICES,
@@ -29,6 +30,7 @@ from .const import (
     CONF_TIME_WINDOW,
     DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD,
     DEFAULT_MAJOR_DELAY_THRESHOLD,
+    DEFAULT_MIN_CONNECTION_TIME,
     DEFAULT_MINOR_DELAY_THRESHOLD,
     DEFAULT_SEVERE_DELAY_THRESHOLD,
     DOMAIN,
@@ -36,6 +38,11 @@ from .const import (
     NIGHT_HOURS,
     PEAK_HOURS,
     STATUS_CANCELLED,
+    STATUS_CONNECTION_DELAYED,
+    STATUS_CONNECTION_MISSED,
+    STATUS_CONNECTION_OK,
+    STATUS_CONNECTION_TIGHT,
+    STATUS_CONNECTION_UNKNOWN,
     STATUS_CRITICAL,
     STATUS_DELAYED,
     STATUS_MAJOR_DELAYS,
@@ -43,6 +50,7 @@ from .const import (
     STATUS_NORMAL,
     STATUS_ON_TIME,
     STATUS_SEVERE_DISRUPTION,
+    TIGHT_CONNECTION_MARGIN,
     UPDATE_INTERVAL_NIGHT,
     UPDATE_INTERVAL_OFF_PEAK,
     UPDATE_INTERVAL_PEAK,
@@ -60,6 +68,17 @@ _STATUS_ORDER: list[str] = [
     STATUS_SEVERE_DISRUPTION,
     STATUS_CRITICAL,
 ]
+
+# Maps each per-connection feasibility status onto the same severity hierarchy
+# used for per-leg statuses, so a missed connection can push the journey's
+# overall_status up without introducing a separate vocabulary.
+_CONNECTION_STATUS_SEVERITY: dict[str, str] = {
+    STATUS_CONNECTION_OK: STATUS_NORMAL,
+    STATUS_CONNECTION_UNKNOWN: STATUS_NORMAL,
+    STATUS_CONNECTION_TIGHT: STATUS_MINOR_DELAYS,
+    STATUS_CONNECTION_DELAYED: STATUS_MAJOR_DELAYS,
+    STATUS_CONNECTION_MISSED: STATUS_CRITICAL,
+}
 
 
 def build_route_id(legs: list[dict[str, Any]]) -> str:
@@ -122,6 +141,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             config.get(
                 CONF_DEPARTED_TRAIN_GRACE_PERIOD, DEFAULT_DEPARTED_TRAIN_GRACE_PERIOD
             )
+        )
+        self.min_connection_time = int(
+            config.get(CONF_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME)
         )
 
         # Delay thresholds (user-configurable)
@@ -351,6 +373,43 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
             raise UpdateFailed(f"Failed to fetch data: {err}") from err
 
+    @staticmethod
+    def _minutes_between(start: str | None, end: str | None) -> int | None:
+        """Return the number of minutes from `start` to `end`.
+
+        Both times are "HH:MM" strings without a date component, so a naive
+        subtraction can be off by a day when the window straddles midnight
+        (e.g. start="23:55", end="00:05"). If the raw difference is more
+        than 12 hours in either direction, `end` is assumed to fall on the
+        other side of a day boundary from `start`.
+
+        Args:
+            start: Reference time, "HH:MM"
+            end: Target time, "HH:MM"
+
+        Returns:
+            Minutes from start to end (negative if end is before start), or
+            None if either time is missing or not in "HH:MM" format
+        """
+        if (
+            not start
+            or not end
+            or not _TIME_FORMAT_RE.match(start)
+            or not _TIME_FORMAT_RE.match(end)
+        ):
+            return None
+
+        start_dt = datetime.strptime(f"2000-01-01 {start}", "%Y-%m-%d %H:%M")
+        end_dt = datetime.strptime(f"2000-01-01 {end}", "%Y-%m-%d %H:%M")
+
+        diff_seconds = (end_dt - start_dt).total_seconds()
+        if diff_seconds < -12 * 3600:
+            end_dt += timedelta(days=1)
+        elif diff_seconds > 12 * 3600:
+            end_dt -= timedelta(days=1)
+
+        return int((end_dt - start_dt).total_seconds() / 60)
+
     def _filter_departed_trains(
         self, services: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
@@ -381,51 +440,25 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 departure_time = service.get("scheduled_departure")
 
-            if not departure_time or not _TIME_FORMAT_RE.match(departure_time):
+            time_diff_minutes = self._minutes_between(current_time_str, departure_time)
+
+            if time_diff_minutes is None:
                 # If we can't parse the time, keep the service
                 filtered_services.append(service)
                 continue
 
-            try:
-                # Parse current time and departure time using a reference date
-                current_dt = datetime.strptime(
-                    f"2000-01-01 {current_time_str}", "%Y-%m-%d %H:%M"
-                )
-                departure_dt = datetime.strptime(
-                    f"2000-01-01 {departure_time}", "%Y-%m-%d %H:%M"
-                )
-
-                # Calculate time difference
-                time_diff_seconds = (departure_dt - current_dt).total_seconds()
-
-                # Handle midnight crossing: if difference > 12 hours in either direction,
-                # adjust for day boundary
-                if time_diff_seconds < -12 * 3600:
-                    # Departure is much earlier in the day, so it's actually tomorrow
-                    departure_dt += timedelta(days=1)
-                    time_diff_seconds = (departure_dt - current_dt).total_seconds()
-                elif time_diff_seconds > 12 * 3600:
-                    # Departure is much later in the day, so it's actually yesterday
-                    departure_dt -= timedelta(days=1)
-                    time_diff_seconds = (departure_dt - current_dt).total_seconds()
-
-                # Keep the train if it hasn't departed yet
-                # Add a grace period to account for update delays and slight delays
-                grace_period_seconds = self.departed_train_grace_period * 60
-                if time_diff_seconds >= -grace_period_seconds:
-                    filtered_services.append(service)
-                else:
-                    _LOGGER.debug(
-                        "Filtering out departed train: scheduled %s, expected %s, current time %s",
-                        service.get("scheduled_departure"),
-                        service.get("expected_departure"),
-                        current_time_str,
-                    )
-
-            except (ValueError, TypeError) as err:
-                # If we can't parse the time, keep the service to be safe
-                _LOGGER.debug("Could not parse departure time for filtering: %s", err)
+            # Keep the train if it hasn't departed yet
+            # Add a grace period to account for update delays and slight delays
+            grace_period_minutes = self.departed_train_grace_period
+            if time_diff_minutes >= -grace_period_minutes:
                 filtered_services.append(service)
+            else:
+                _LOGGER.debug(
+                    "Filtering out departed train: scheduled %s, expected %s, current time %s",
+                    service.get("scheduled_departure"),
+                    service.get("expected_departure"),
+                    current_time_str,
+                )
 
         return filtered_services
 
@@ -543,6 +576,91 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             return STATUS_NORMAL
         return max(statuses, key=_STATUS_ORDER.index)
 
+    def _evaluate_connection(
+        self, leg_from: dict[str, Any], leg_to: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Evaluate whether the change between two adjacent legs is feasible.
+
+        Compares the incoming leg's next train's expected arrival at the
+        interchange against the outgoing leg's tracked services, walking
+        forward to find the first non-cancelled service that leaves with at
+        least `min_connection_time` minutes to spare.
+
+        Args:
+            leg_from: Parsed data for the leg arriving at the interchange
+            leg_to: Parsed data for the leg departing from the interchange
+
+        Returns:
+            Dict describing the connection: station, timings, buffer, and a
+            status of Connection OK / Tight Connection / Delayed Connection /
+            Missed Connection / Unknown
+        """
+        base: dict[str, Any] = {
+            "station": leg_from.get("destination"),
+            "station_name": leg_from.get("destination_name"),
+            "arrival_time": None,
+            "connecting_departure": None,
+            "connecting_service_id": None,
+            "buffer_minutes": None,
+            "min_required_minutes": self.min_connection_time,
+            "feasible": None,
+            "status": STATUS_CONNECTION_UNKNOWN,
+        }
+
+        next_train_from = leg_from.get("next_train")
+        if not next_train_from:
+            return base
+
+        arrival = next_train_from.get("estimated_arrival") or next_train_from.get(
+            "scheduled_arrival"
+        )
+        if not arrival or not _TIME_FORMAT_RE.match(arrival):
+            return base
+
+        base["arrival_time"] = arrival
+
+        next_train_to = leg_to.get("next_train")
+        matched_service = None
+        matched_buffer = None
+        for service in leg_to.get("services", []):
+            if service.get("is_cancelled", False):
+                continue
+            departure = service.get("expected_departure") or service.get(
+                "scheduled_departure"
+            )
+            buffer_minutes = self._minutes_between(arrival, departure)
+            if buffer_minutes is None:
+                continue
+            if buffer_minutes >= self.min_connection_time:
+                matched_service = service
+                matched_buffer = buffer_minutes
+                break
+
+        if matched_service is None:
+            base["feasible"] = False
+            base["status"] = STATUS_CONNECTION_MISSED
+            return base
+
+        base["connecting_departure"] = matched_service.get(
+            "expected_departure"
+        ) or matched_service.get("scheduled_departure")
+        base["connecting_service_id"] = matched_service.get("service_id")
+        base["buffer_minutes"] = matched_buffer
+        base["feasible"] = True
+
+        is_next_train = (
+            next_train_to is not None
+            and matched_service.get("service_id") == next_train_to.get("service_id")
+        )
+        if not is_next_train:
+            base["status"] = STATUS_CONNECTION_DELAYED
+        elif matched_buffer >= self.min_connection_time + TIGHT_CONNECTION_MARGIN:
+            base["status"] = STATUS_CONNECTION_OK
+        else:
+            base["status"] = STATUS_CONNECTION_TIGHT
+
+        return base
+
     def _parse_data(
         self, data: dict[str, Any] | list[dict[str, Any]]
     ) -> dict[str, Any]:
@@ -619,6 +737,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 if message not in nrcc_messages:
                     nrcc_messages.append(message)
 
+        connections = [
+            self._evaluate_connection(leg_results[i], leg_results[i + 1])
+            for i in range(len(leg_results) - 1)
+        ]
+        journey_feasible = all(conn["feasible"] is not False for conn in connections)
+
         return {
             "origin": self.legs[0]["origin"],
             "origin_name": leg_results[0]["origin_name"],
@@ -636,6 +760,7 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             "next_train": leg_results[0]["next_train"],
             "overall_status": self._combine_statuses(
                 [lr["overall_status"] for lr in leg_results]
+                + [_CONNECTION_STATUS_SEVERITY[conn["status"]] for conn in connections]
             ),
             "max_delay_minutes": max(
                 (lr["max_delay_minutes"] for lr in leg_results), default=0
@@ -647,6 +772,8 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             "multi_destination": False,
             "is_multi_leg": True,
             "legs": leg_results,
+            "connections": connections,
+            "journey_feasible": journey_feasible,
             "last_updated": dt_util.now().isoformat(),
             "next_update": (dt_util.now() + self.update_interval).isoformat(),
             "nrcc_messages": nrcc_messages,

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -20,6 +20,7 @@ from .const import (
     ATTR_CANCELLATION_REASON,
     ATTR_CANCELLED_COUNT,
     ATTR_CANCELLED_COUNT_TODAY,
+    ATTR_CONNECTIONS,
     ATTR_DAILY_BREAKDOWN,
     ATTR_DELAY_MINUTES,
     ATTR_DELAY_REASON,
@@ -31,6 +32,7 @@ from .const import (
     ATTR_EXPECTED_DEPARTURE,
     ATTR_IS_CANCELLED,
     ATTR_IS_MULTI_LEG,
+    ATTR_JOURNEY_FEASIBLE,
     ATTR_LEGS,
     ATTR_ON_TIME_COUNT,
     ATTR_ON_TIME_COUNT_TODAY,
@@ -59,6 +61,10 @@ from .const import (
     CONF_COMMUTE_NAME,
     CONF_NUM_SERVICES,
     DOMAIN,
+    STATUS_CONNECTION_DELAYED,
+    STATUS_CONNECTION_MISSED,
+    STATUS_CONNECTION_OK,
+    STATUS_CONNECTION_TIGHT,
     STATUS_CRITICAL,
     STATUS_MAJOR_DELAYS,
     STATUS_MINOR_DELAYS,
@@ -168,6 +174,10 @@ async def async_setup_entry(
                 entities.append(
                     LegTrainSensor(coordinator, entry, leg_index, train_number)
                 )
+        for connection_index in range(1, len(coordinator.legs)):
+            entities.append(
+                ConnectionStatusSensor(coordinator, entry, connection_index)
+            )
     else:
         entities.append(
             NextTrainSensor(coordinator, entry)
@@ -343,6 +353,8 @@ class CommuteSummarySensor(NationalRailCommuteEntity, SensorEntity):
         if data.get("is_multi_leg"):
             attrs[ATTR_IS_MULTI_LEG] = True
             attrs[ATTR_LEGS] = data.get("legs", [])
+            attrs[ATTR_CONNECTIONS] = data.get("connections", [])
+            attrs[ATTR_JOURNEY_FEASIBLE] = data.get("journey_feasible")
 
         return attrs
 
@@ -1043,6 +1055,91 @@ class LegStatusSensor(CommuteStatusSensor):
         if len(legs) < self._leg_index:
             return None
         return legs[self._leg_index - 1]
+
+
+class ConnectionStatusSensor(NationalRailCommuteEntity, SensorEntity):
+    """Sensor for whether a change between two legs is achievable.
+
+    One entity per interchange in a multi-leg journey, comparing the
+    incoming leg's expected arrival against the outgoing leg's departures.
+    """
+
+    def __init__(
+        self,
+        coordinator: NationalRailDataUpdateCoordinator,
+        entry: ConfigEntry,
+        connection_index: int,
+    ) -> None:
+        """Initialize the connection status sensor.
+
+        Args:
+            coordinator: Data coordinator
+            entry: Config entry
+            connection_index: 1-indexed position of this connection (the
+                change between leg `connection_index` and the next leg)
+        """
+        super().__init__(coordinator, entry)
+
+        self._connection_index = connection_index
+        self._attr_name = f"Connection {connection_index} Status"
+        self._attr_unique_id = f"{entry.entry_id}_connection{connection_index}_status"
+
+    def _get_connection_data(self) -> dict[str, Any] | None:
+        """Return this sensor's connection data, or None if unavailable."""
+        if not self.coordinator.data:
+            return None
+        connections = self.coordinator.data.get("connections", [])
+        if len(connections) < self._connection_index:
+            return None
+        return connections[self._connection_index - 1]
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor.
+
+        Returns:
+            Connection status: Connection OK, Tight Connection, Delayed
+            Connection, Missed Connection, or Unknown
+        """
+        connection = self._get_connection_data()
+        if not connection:
+            return None
+        return connection.get("status")
+
+    @property
+    def icon(self) -> str:
+        """Return icon based on connection status.
+
+        Returns:
+            Icon string
+        """
+        status = self.native_value
+
+        if status == STATUS_CONNECTION_MISSED:
+            return "mdi:alert-octagon"
+        if status == STATUS_CONNECTION_DELAYED:
+            return "mdi:clock-alert"
+        if status == STATUS_CONNECTION_TIGHT:
+            return "mdi:clock-alert-outline"
+        if status == STATUS_CONNECTION_OK:
+            return "mdi:transit-connection-variant"
+
+        return "mdi:help-circle-outline"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes.
+
+        Returns:
+            Dictionary of attributes describing the connection
+        """
+        connection = self._get_connection_data()
+        if not connection:
+            return {}
+
+        attrs = dict(connection)
+        attrs["last_updated"] = (self.coordinator.data or {}).get("last_updated")
+        return attrs
 
 
 class LegTrainSensor(TrainSensor):

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -36,7 +36,8 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "min_connection_time": "Minimum Connection Time (minutes)"
         }
       },
       "return_journey": {
@@ -72,7 +73,8 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "min_connection_time": "Minimum Connection Time (minutes)"
         }
       }
     },

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -36,7 +36,8 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "min_connection_time": "Minimum Connection Time (minutes)"
         }
       },
       "return_journey": {
@@ -72,7 +73,8 @@
           "major_delay_threshold": "Major Delays Threshold (minutes)",
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
-          "departed_train_grace_period": "Departed Train Grace Period (minutes)"
+          "departed_train_grace_period": "Departed Train Grace Period (minutes)",
+          "min_connection_time": "Minimum Connection Time (minutes)"
         }
       }
     },

--- a/tests/test_config_flow_multi_leg.py
+++ b/tests/test_config_flow_multi_leg.py
@@ -8,6 +8,8 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.my_rail_commute.const import (
     CONF_ADD_LEG,
     CONF_ADD_RETURN_JOURNEY,
@@ -16,6 +18,7 @@ from custom_components.my_rail_commute.const import (
     CONF_LEG_DESTINATION,
     CONF_LEGS,
     CONF_MAJOR_DELAY_THRESHOLD,
+    CONF_MIN_CONNECTION_TIME,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
     CONF_NUM_SERVICES,
@@ -23,6 +26,7 @@ from custom_components.my_rail_commute.const import (
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
     DEFAULT_MAJOR_DELAY_THRESHOLD,
+    DEFAULT_MIN_CONNECTION_TIME,
     DEFAULT_MINOR_DELAY_THRESHOLD,
     DEFAULT_SEVERE_DELAY_THRESHOLD,
     DOMAIN,
@@ -348,3 +352,225 @@ class TestMultiLegReturnJourney:
         entries = hass.config_entries.async_entries(DOMAIN)
         reverse_entry = next(e for e in entries if e.unique_id == "RDG_OXF_PAD")
         assert reverse_entry.data[CONF_LEGS] == reverse_data[CONF_LEGS]
+
+
+class TestMinConnectionTimeField:
+    """Tests for the min_connection_time field, which only applies to
+    multi-leg journeys (a single-leg journey has no connection to time)."""
+
+    async def test_single_leg_settings_step_omits_min_connection_time(
+        self, hass: HomeAssistant
+    ):
+        """A single-leg journey's settings form has no min_connection_time field."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "RDG"},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_LEG: False}
+        )
+        assert result["step_id"] == "settings"
+
+        schema_mapping = result["data_schema"].schema
+        assert not any(
+            str(key) == CONF_MIN_CONNECTION_TIME for key in schema_mapping
+        )
+
+        result = await _submit_settings(hass, result["flow_id"])
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert CONF_MIN_CONNECTION_TIME not in result["data"]
+
+    async def test_multi_leg_settings_step_offers_and_persists_min_connection_time(
+        self, hass: HomeAssistant
+    ):
+        """A multi-leg journey's settings form offers min_connection_time, and
+        the submitted value is persisted on the created entry."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Oxford",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "OXF"},
+            )
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "RDG"},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_LEG: False}
+        )
+        assert result["step_id"] == "settings"
+
+        schema_mapping = result["data_schema"].schema
+        assert any(str(key) == CONF_MIN_CONNECTION_TIME for key in schema_mapping)
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_COMMUTE_NAME: "Test Journey",
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: False,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_MIN_CONNECTION_TIME: 8,
+            },
+        )
+        assert result["step_id"] == "return_journey"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_MIN_CONNECTION_TIME] == 8
+
+    async def test_multi_leg_settings_step_defaults_min_connection_time(
+        self, hass: HomeAssistant
+    ):
+        """Submitting the multi-leg settings step without min_connection_time
+        falls back to the schema default, same as the other numeric fields."""
+        result = await _start_flow(hass)
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Oxford",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ORIGIN: "PAD", CONF_DESTINATION: "OXF"},
+            )
+
+        with patch(
+            "custom_components.my_rail_commute.config_flow.validate_stations",
+            return_value={
+                "origin_name": "London Paddington",
+                "destination_name": "Reading",
+            },
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADD_LEG: True, CONF_LEG_DESTINATION: "RDG"},
+            )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_LEG: False}
+        )
+
+        result = await _submit_settings(hass, result["flow_id"])
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADD_RETURN_JOURNEY: False}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_MIN_CONNECTION_TIME] == DEFAULT_MIN_CONNECTION_TIME
+
+
+class TestMinConnectionTimeOptionsFlow:
+    """Tests for the min_connection_time field in the options flow."""
+
+    @staticmethod
+    def _multi_leg_entry() -> MockConfigEntry:
+        return MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_API_KEY: "test_api_key_12345",
+                CONF_ORIGIN: "PAD",
+                CONF_DESTINATION: "OXF",
+                CONF_LEGS: [
+                    {"origin": "PAD", "destination": "RDG"},
+                    {"origin": "RDG", "destination": "OXF"},
+                ],
+                CONF_COMMUTE_NAME: "Test Journey",
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: True,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_MIN_CONNECTION_TIME: DEFAULT_MIN_CONNECTION_TIME,
+            },
+            unique_id="PAD_RDG_OXF",
+        )
+
+    async def test_options_flow_offers_min_connection_time_for_multi_leg_entry(
+        self, hass: HomeAssistant
+    ):
+        """The options form for a multi-leg entry includes min_connection_time."""
+        entry = self._multi_leg_entry()
+        entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+        schema_mapping = result["data_schema"].schema
+        assert any(str(key) == CONF_MIN_CONNECTION_TIME for key in schema_mapping)
+
+    async def test_options_flow_updates_min_connection_time(self, hass: HomeAssistant):
+        """Submitting the options form updates min_connection_time on the entry."""
+        entry = self._multi_leg_entry()
+        entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TIME_WINDOW: 60,
+                CONF_NUM_SERVICES: 3,
+                CONF_NIGHT_UPDATES: True,
+                CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+                CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+                CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+                CONF_MIN_CONNECTION_TIME: 12,
+            },
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_MIN_CONNECTION_TIME] == 12
+
+    async def test_options_flow_omits_min_connection_time_for_single_leg_entry(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """A single-leg entry's options form has no min_connection_time field."""
+        mock_config_entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+
+        schema_mapping = result["data_schema"].schema
+        assert not any(
+            str(key) == CONF_MIN_CONNECTION_TIME for key in schema_mapping
+        )

--- a/tests/test_coordinator_multi_leg.py
+++ b/tests/test_coordinator_multi_leg.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.const import CONF_API_KEY
@@ -16,6 +16,7 @@ from custom_components.my_rail_commute.const import (
     CONF_DESTINATION,
     CONF_LEGS,
     CONF_MAJOR_DELAY_THRESHOLD,
+    CONF_MIN_CONNECTION_TIME,
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
     CONF_NUM_SERVICES,
@@ -23,9 +24,15 @@ from custom_components.my_rail_commute.const import (
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
     DEFAULT_MAJOR_DELAY_THRESHOLD,
+    DEFAULT_MIN_CONNECTION_TIME,
     DEFAULT_MINOR_DELAY_THRESHOLD,
     DEFAULT_SEVERE_DELAY_THRESHOLD,
     STATUS_CANCELLED,
+    STATUS_CONNECTION_DELAYED,
+    STATUS_CONNECTION_MISSED,
+    STATUS_CONNECTION_OK,
+    STATUS_CONNECTION_TIGHT,
+    STATUS_CONNECTION_UNKNOWN,
     STATUS_CRITICAL,
     STATUS_DELAYED,
     STATUS_MAJOR_DELAYS,
@@ -42,14 +49,39 @@ from custom_components.my_rail_commute.coordinator import (
 _TEST_TIME = datetime(2024, 1, 15, 8, 0, 0, tzinfo=dt_util.UTC)
 
 
+def _shift_time(time_str: str, minutes: int) -> str:
+    """Shift an "HH:MM" string by `minutes` (may cross midnight)."""
+    dt = datetime.strptime(f"2000-01-01 {time_str}", "%Y-%m-%d %H:%M") + timedelta(
+        minutes=minutes
+    )
+    return dt.strftime("%H:%M")
+
+
 def _make_service(
-    service_id: str, status: str = STATUS_ON_TIME, delay_minutes: int = 0
+    service_id: str,
+    status: str = STATUS_ON_TIME,
+    delay_minutes: int = 0,
+    scheduled_departure: str = "09:00",
+    scheduled_arrival: str = "09:30",
+    estimated_arrival: str | None = None,
 ) -> dict:
-    """Build a minimal already-parsed service dict."""
+    """Build a minimal already-parsed service dict.
+
+    Defaults depart at 09:00 and arrive at 09:30 so that a second leg's
+    default service (also departing 09:00) is NOT reachable from this one —
+    tests that chain two legs and don't care about connection feasibility
+    should pass an explicit `scheduled_departure` for the second leg's
+    service that falls comfortably after 09:30.
+    """
     is_cancelled = status == STATUS_CANCELLED
+    expected_departure = (
+        scheduled_departure
+        if delay_minutes == 0
+        else _shift_time(scheduled_departure, delay_minutes)
+    )
     return {
-        "scheduled_departure": "09:00",
-        "expected_departure": "09:00" if delay_minutes == 0 else "09:10",
+        "scheduled_departure": scheduled_departure,
+        "expected_departure": expected_departure,
         "platform": "1",
         "operator": "Test Operator",
         "service_id": service_id,
@@ -59,8 +91,8 @@ def _make_service(
         "is_cancelled": is_cancelled,
         "cancellation_reason": "Signal failure" if is_cancelled else None,
         "delay_reason": "Late running" if delay_minutes else None,
-        "scheduled_arrival": "09:30",
-        "estimated_arrival": "09:30",
+        "scheduled_arrival": scheduled_arrival,
+        "estimated_arrival": estimated_arrival or scheduled_arrival,
         "destination": "Destination",
     }
 
@@ -76,7 +108,9 @@ def _make_leg_response(origin_name: str, destination_name: str, services: list) 
     }
 
 
-def _make_config(legs: list[dict]) -> dict:
+def _make_config(
+    legs: list[dict], min_connection_time: int = DEFAULT_MIN_CONNECTION_TIME
+) -> dict:
     """Build a multi-leg config dict."""
     return {
         CONF_API_KEY: "test_key",
@@ -89,6 +123,7 @@ def _make_config(legs: list[dict]) -> dict:
         CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
         CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
         CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+        CONF_MIN_CONNECTION_TIME: min_connection_time,
     }
 
 
@@ -249,7 +284,12 @@ async def test_multi_leg_overall_status_is_worst_case_across_legs(
         {"origin": "RDG", "destination": "OXF"},
     ]
     leg1_service = _make_service("svc1", **leg1_status_kwargs)
-    leg2_service = _make_service("svc2", **leg2_status_kwargs)
+    # Departs comfortably after leg1's 09:30 arrival so this test only
+    # exercises per-leg severity combination, not connection feasibility
+    # (which is covered separately below).
+    leg2_service = _make_service(
+        "svc2", scheduled_departure="09:45", **leg2_status_kwargs
+    )
     if leg1_status_kwargs.get("delay_minutes"):
         leg1_service["status"] = STATUS_DELAYED
     if leg2_status_kwargs.get("delay_minutes"):
@@ -352,3 +392,221 @@ async def test_single_leg_output_shape_unchanged(hass: HomeAssistant) -> None:
     assert set(data.keys()) == expected_keys
     assert "is_multi_leg" not in data
     assert "legs" not in data
+
+
+def _make_leg_result(
+    destination: str, destination_name: str, next_train: dict | None
+) -> dict:
+    """Build a minimal parsed leg_result dict with just the fields
+    `_evaluate_connection` reads from the *incoming* leg."""
+    return {
+        "destination": destination,
+        "destination_name": destination_name,
+        "next_train": next_train,
+    }
+
+
+@pytest.fixture(name="two_leg_coordinator")
+def two_leg_coordinator_fixture(hass: HomeAssistant) -> NationalRailDataUpdateCoordinator:
+    """A coordinator configured for a two-leg PAD -> RDG -> OXF journey."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    return NationalRailDataUpdateCoordinator(hass, AsyncMock(), _make_config(legs))
+
+
+async def test_evaluate_connection_ok_with_comfortable_buffer(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """A generous buffer on the outgoing leg's own next train is Connection OK."""
+    leg_from = _make_leg_result("RDG", "Reading", _make_service("svc1"))
+    outgoing = _make_service("svc2", scheduled_departure="09:45")
+    leg_to = {"services": [outgoing], "next_train": outgoing}
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_OK
+    assert conn["feasible"] is True
+    assert conn["buffer_minutes"] == 15
+    assert conn["arrival_time"] == "09:30"
+    assert conn["connecting_departure"] == "09:45"
+    assert conn["connecting_service_id"] == "svc2"
+
+
+async def test_evaluate_connection_tight_below_margin(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """A buffer that clears the minimum but not the comfort margin is Tight."""
+    leg_from = _make_leg_result("RDG", "Reading", _make_service("svc1"))
+    outgoing = _make_service("svc2", scheduled_departure="09:36")
+    leg_to = {"services": [outgoing], "next_train": outgoing}
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_TIGHT
+    assert conn["feasible"] is True
+    assert conn["buffer_minutes"] == 6
+
+
+async def test_evaluate_connection_missed_when_no_service_has_enough_buffer(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """No tracked outgoing service leaves enough time after arrival."""
+    leg_from = _make_leg_result("RDG", "Reading", _make_service("svc1"))
+    outgoing = _make_service("svc2", scheduled_departure="09:20")
+    leg_to = {"services": [outgoing], "next_train": outgoing}
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_MISSED
+    assert conn["feasible"] is False
+    assert conn["connecting_service_id"] is None
+
+
+async def test_evaluate_connection_delayed_when_a_later_train_is_needed(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """Feasible only on a later train than the outgoing leg's own next train."""
+    leg_from = _make_leg_result("RDG", "Reading", _make_service("svc1"))
+    unreachable_next = _make_service("svc2a", scheduled_departure="09:20")
+    reachable_later = _make_service("svc2b", scheduled_departure="09:50")
+    leg_to = {
+        "services": [unreachable_next, reachable_later],
+        "next_train": unreachable_next,
+    }
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_DELAYED
+    assert conn["feasible"] is True
+    assert conn["connecting_service_id"] == "svc2b"
+
+
+async def test_evaluate_connection_unknown_when_incoming_leg_has_no_next_train(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """No next train on the incoming leg means feasibility can't be judged."""
+    leg_from = _make_leg_result("RDG", "Reading", None)
+    outgoing = _make_service("svc2", scheduled_departure="09:45")
+    leg_to = {"services": [outgoing], "next_train": outgoing}
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_UNKNOWN
+    assert conn["feasible"] is None
+
+
+async def test_evaluate_connection_unknown_when_arrival_time_unparseable(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """An unparseable/missing arrival time is treated as Unknown, not Missed."""
+    next_train = {**_make_service("svc1"), "estimated_arrival": None, "scheduled_arrival": None}
+    leg_from = _make_leg_result("RDG", "Reading", next_train)
+    outgoing = _make_service("svc2", scheduled_departure="09:45")
+    leg_to = {"services": [outgoing], "next_train": outgoing}
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_UNKNOWN
+    assert conn["feasible"] is None
+
+
+async def test_missed_connection_elevates_overall_status_even_with_normal_legs(
+    hass: HomeAssistant,
+) -> None:
+    """A missed connection alone pushes overall_status to Critical, even when
+    both legs are individually Normal."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    # leg1 arrives 09:30; leg2's only service departs 09:20 (before arrival)
+    leg1_service = _make_service("svc1")
+    leg2_service = _make_service("svc2", scheduled_departure="09:20")
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [leg1_service]),
+            _make_leg_response("Reading", "Oxford", [leg2_service]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(hass, api, _make_config(legs))
+        data = await coordinator._async_update_data()
+
+    assert data["legs"][0]["overall_status"] == STATUS_NORMAL
+    assert data["legs"][1]["overall_status"] == STATUS_NORMAL
+    assert data["connections"][0]["status"] == STATUS_CONNECTION_MISSED
+    assert data["journey_feasible"] is False
+    assert data["overall_status"] == STATUS_CRITICAL
+
+
+async def test_connection_feasible_journey_reports_ok_and_feasible_true(
+    hass: HomeAssistant,
+) -> None:
+    """A comfortably-timed connection reports OK, feasible, and Normal overall."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    leg1_service = _make_service("svc1")
+    leg2_service = _make_service("svc2", scheduled_departure="09:45")
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [leg1_service]),
+            _make_leg_response("Reading", "Oxford", [leg2_service]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(hass, api, _make_config(legs))
+        data = await coordinator._async_update_data()
+
+    assert data["connections"][0]["status"] == STATUS_CONNECTION_OK
+    assert data["journey_feasible"] is True
+    assert data["overall_status"] == STATUS_NORMAL
+
+
+async def test_min_connection_time_config_affects_feasibility(
+    hass: HomeAssistant,
+) -> None:
+    """Raising min_connection_time can turn a previously-OK buffer into Missed."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    leg1_service = _make_service("svc1")
+    # 7-minute buffer: feasible under the default 5-minute minimum, infeasible
+    # once min_connection_time is raised to 10.
+    leg2_service = _make_service("svc2", scheduled_departure="09:37")
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [leg1_service]),
+            _make_leg_response("Reading", "Oxford", [leg2_service]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(
+            hass, api, _make_config(legs, min_connection_time=10)
+        )
+        data = await coordinator._async_update_data()
+
+    assert data["connections"][0]["status"] == STATUS_CONNECTION_MISSED
+    assert data["journey_feasible"] is False

--- a/tests/test_sensor_multi_leg.py
+++ b/tests/test_sensor_multi_leg.py
@@ -31,14 +31,20 @@ from custom_components.my_rail_commute.const import (
 _TEST_TIME = datetime(2024, 1, 15, 8, 0, 0, tzinfo=dt_util.UTC)
 
 
-def _leg_response(origin_name: str, destination_name: str, service_id: str) -> dict:
+def _leg_response(
+    origin_name: str,
+    destination_name: str,
+    service_id: str,
+    departure: str = "08:35",
+    arrival: str = "08:55",
+) -> dict:
     return {
         "location_name": origin_name,
         "destination_name": destination_name,
         "services": [
             {
-                "scheduled_departure": "08:35",
-                "expected_departure": "08:35",
+                "scheduled_departure": departure,
+                "expected_departure": departure,
                 "platform": "3",
                 "operator": "Great Western Railway",
                 "service_id": service_id,
@@ -48,8 +54,8 @@ def _leg_response(origin_name: str, destination_name: str, service_id: str) -> d
                 "is_cancelled": False,
                 "cancellation_reason": None,
                 "delay_reason": None,
-                "scheduled_arrival": "08:55",
-                "estimated_arrival": "08:55",
+                "scheduled_arrival": arrival,
+                "estimated_arrival": arrival,
                 "destination": destination_name,
             }
         ],
@@ -91,7 +97,9 @@ async def test_multi_leg_entry_creates_per_leg_sensors(
     mock_api_client.get_departure_board = AsyncMock(
         side_effect=[
             _leg_response("Paddington", "Reading", "svc-leg1"),
-            _leg_response("Reading", "Oxford", "svc-leg2"),
+            _leg_response(
+                "Reading", "Oxford", "svc-leg2", departure="09:15", arrival="09:35"
+            ),
         ]
     )
 
@@ -169,7 +177,9 @@ async def test_multi_leg_device_id_uses_full_chain(
     mock_api_client.get_departure_board = AsyncMock(
         side_effect=[
             _leg_response("Paddington", "Reading", "svc-leg1"),
-            _leg_response("Reading", "Oxford", "svc-leg2"),
+            _leg_response(
+                "Reading", "Oxford", "svc-leg2", departure="09:15", arrival="09:35"
+            ),
         ]
     )
 
@@ -181,3 +191,100 @@ async def test_multi_leg_device_id_uses_full_chain(
     device = device_reg.async_get_device(identifiers={(DOMAIN, "PAD_RDG_OXF")})
     assert device is not None
     assert device.name == "Test Journey"
+
+
+async def test_connection_status_sensor_created_and_ok(
+    hass: HomeAssistant, multi_leg_entry, mock_api_client
+) -> None:
+    """A two-leg journey creates one Connection Status sensor per interchange,
+    reporting Connection OK when the buffer is comfortable."""
+    mock_api_client.get_departure_board = AsyncMock(
+        side_effect=[
+            _leg_response("Paddington", "Reading", "svc-leg1"),
+            _leg_response(
+                "Reading", "Oxford", "svc-leg2", departure="09:15", arrival="09:35"
+            ),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        multi_leg_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(multi_leg_entry.entry_id)
+        await hass.async_block_till_done()
+
+    connection_status = hass.states.get("sensor.test_journey_connection_1_status")
+    assert connection_status is not None
+    assert connection_status.state == "Connection OK"
+    assert connection_status.attributes["station"] == "RDG"
+    assert connection_status.attributes["feasible"] is True
+    assert connection_status.attributes["buffer_minutes"] == 20
+
+    # Only one connection exists for a two-leg journey
+    assert hass.states.get("sensor.test_journey_connection_2_status") is None
+
+
+async def test_connection_status_sensor_missed_elevates_overall_status(
+    hass: HomeAssistant, multi_leg_entry, mock_api_client
+) -> None:
+    """When the outgoing leg's only service departs before the incoming leg
+    arrives, the connection is Missed and the overall Status becomes Critical
+    even though both legs individually report Normal."""
+    mock_api_client.get_departure_board = AsyncMock(
+        side_effect=[
+            _leg_response("Paddington", "Reading", "svc-leg1"),
+            _leg_response(
+                "Reading", "Oxford", "svc-leg2", departure="08:40", arrival="09:00"
+            ),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        multi_leg_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(multi_leg_entry.entry_id)
+        await hass.async_block_till_done()
+
+    leg1_status = hass.states.get("sensor.test_journey_leg_1_status")
+    leg2_status = hass.states.get("sensor.test_journey_leg_2_status")
+    connection_status = hass.states.get("sensor.test_journey_connection_1_status")
+    overall_status = hass.states.get("sensor.test_journey_status")
+
+    assert leg1_status.state == "Normal"
+    assert leg2_status.state == "Normal"
+    assert connection_status.state == "Missed Connection"
+    assert connection_status.attributes["feasible"] is False
+    assert overall_status.state == "Critical"
+
+
+async def test_summary_sensor_exposes_connections_and_journey_feasible(
+    hass: HomeAssistant, multi_leg_entry, mock_api_client
+) -> None:
+    """The combined Summary sensor exposes connections and journey_feasible
+    attributes for a multi-leg journey."""
+    mock_api_client.get_departure_board = AsyncMock(
+        side_effect=[
+            _leg_response("Paddington", "Reading", "svc-leg1"),
+            _leg_response(
+                "Reading", "Oxford", "svc-leg2", departure="09:15", arrival="09:35"
+            ),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        multi_leg_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(multi_leg_entry.entry_id)
+        await hass.async_block_till_done()
+
+    summary = hass.states.get("sensor.test_journey_summary")
+    assert summary is not None
+    assert summary.attributes["journey_feasible"] is True
+    assert len(summary.attributes["connections"]) == 1
+    assert summary.attributes["connections"][0]["status"] == "Connection OK"


### PR DESCRIPTION
Previously overall_status was purely the worst per-leg severity and never
checked whether a connection could actually be made. Add per-interchange
feasibility evaluation (comparing the incoming leg's expected arrival
against the outgoing leg's departures, with a configurable minimum
connection time) and fold it into overall_status, so a missed connection
is reflected even when every leg individually looks fine.

- New Connection Status sensor per interchange, plus connections/
  journey_feasible on the combined Summary sensor
- New configurable "Minimum Connection Time" setting for multi-leg journeys