### PR TITLE
feat(coordinator): add option to only show catchable multi-leg services

### DIFF
--- a/custom_components/my_rail_commute/config_flow.py
+++ b/custom_components/my_rail_commute/config_flow.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
     CONF_NUM_SERVICES,
+    CONF_ONLY_CATCHABLE_SERVICES,
     CONF_ORIGIN,
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
@@ -202,6 +203,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._minor_delay_threshold: int | None = None
         self._departed_train_grace_period: int | None = None
         self._min_connection_time: int | None = None
+        self._only_catchable_services: bool = False
         self._nearby_stations: list[tuple[float, dict]] | None = None
         self._legs: list[dict[str, Any]] = []
         self._leg_names: list[dict[str, str]] = []
@@ -550,6 +552,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._min_connection_time = user_input.get(
                         CONF_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME
                     )
+                    self._only_catchable_services = user_input.get(
+                        CONF_ONLY_CATCHABLE_SERVICES, False
+                    )
 
                 # Set unique ID based on the full route chain (all-departures
                 # gets a distinct suffix; single-leg routes match the historical format)
@@ -665,6 +670,12 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     mode=selector.NumberSelectorMode.SLIDER,
                 ),
             )
+            schema_dict[
+                vol.Required(
+                    CONF_ONLY_CATCHABLE_SERVICES,
+                    default=False,
+                )
+            ] = selector.BooleanSelector()
 
         data_schema = vol.Schema(schema_dict)
 
@@ -723,6 +734,9 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     reverse_data[CONF_LEGS] = reversed_legs
                     reverse_data[CONF_MIN_CONNECTION_TIME] = (
                         self._min_connection_time or DEFAULT_MIN_CONNECTION_TIME
+                    )
+                    reverse_data[CONF_ONLY_CATCHABLE_SERVICES] = (
+                        self._only_catchable_services
                     )
 
                 self.hass.async_create_task(
@@ -795,6 +809,7 @@ class NationalRailCommuteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data[CONF_MIN_CONNECTION_TIME] = (
                 self._min_connection_time or DEFAULT_MIN_CONNECTION_TIME
             )
+            data[CONF_ONLY_CATCHABLE_SERVICES] = self._only_catchable_services
         return self.async_create_entry(title=self._commute_name, data=data)
 
     @staticmethod
@@ -977,6 +992,15 @@ class NationalRailCommuteOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.NumberSelectorMode.SLIDER,
                 ),
             )
+            schema_dict[
+                vol.Required(
+                    CONF_ONLY_CATCHABLE_SERVICES,
+                    default=options.get(
+                        CONF_ONLY_CATCHABLE_SERVICES,
+                        current_data.get(CONF_ONLY_CATCHABLE_SERVICES, False),
+                    ),
+                )
+            ] = selector.BooleanSelector()
 
         data_schema = vol.Schema(schema_dict)
 

--- a/custom_components/my_rail_commute/const.py
+++ b/custom_components/my_rail_commute/const.py
@@ -23,6 +23,7 @@ CONF_LEGS: Final = "legs"
 CONF_ADD_LEG: Final = "add_leg"
 CONF_LEG_DESTINATION: Final = "leg_destination"
 CONF_MIN_CONNECTION_TIME: Final = "min_connection_time"
+CONF_ONLY_CATCHABLE_SERVICES: Final = "only_catchable_services"
 
 # Legacy config keys (for migration)
 CONF_DISRUPTION_SINGLE_DELAY: Final = "disruption_single_delay"
@@ -148,6 +149,7 @@ ATTR_LEGS: Final = "legs"
 ATTR_IS_MULTI_LEG: Final = "is_multi_leg"
 ATTR_CONNECTIONS: Final = "connections"
 ATTR_JOURNEY_FEASIBLE: Final = "journey_feasible"
+ATTR_CATCHABLE: Final = "catchable"
 
 # API Error Messages
 ERROR_AUTH: Final = "Authentication failed. Please check your API key."

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
     CONF_NUM_SERVICES,
+    CONF_ONLY_CATCHABLE_SERVICES,
     CONF_ORIGIN,
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
@@ -144,6 +145,9 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.min_connection_time = int(
             config.get(CONF_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME)
+        )
+        self.only_catchable_services = bool(
+            config.get(CONF_ONLY_CATCHABLE_SERVICES, False)
         )
 
         # Delay thresholds (user-configurable)
@@ -271,13 +275,21 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
                 # Fetch each leg sequentially (not concurrently) so the shared
                 # API client's rate limiter can throttle correctly between calls
                 raw_leg_data: list[dict[str, Any]] = []
+                # When filtering to catchable-only, over-fetch so there's a
+                # large enough candidate pool to filter down from and match
+                # connections against (mirrors all_departures' over-fetch).
+                leg_num_rows = (
+                    max(self.num_services, 20)
+                    if self.only_catchable_services
+                    else self.num_services
+                )
                 for leg in self.legs:
                     raw_leg_data.append(
                         await self.api.get_departure_board(
                             leg["origin"],
                             destination_crs=leg["destination"],
                             time_window=self.time_window,
-                            num_rows=self.num_services,
+                            num_rows=leg_num_rows,
                         )
                     )
 
@@ -497,24 +509,40 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         return groups
 
     def _parse_leg_data(
-        self, leg: dict[str, Any], raw_data: dict[str, Any]
+        self,
+        leg: dict[str, Any],
+        raw_data: dict[str, Any],
+        next_leg_services: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Parse and enrich a single leg's raw API data.
 
         Args:
             leg: The leg's {"origin", "destination"} config
             raw_data: Raw departure board data for this leg
+            next_leg_services: Raw services of the following leg, used to tag
+                each service as catchable/not; None for the last leg (or a
+                single-leg journey), which has nothing to connect onto
 
         Returns:
             Parsed per-leg data with additional calculated fields
         """
         services = raw_data.get("services", [])
 
-        # Limit to configured number of services
-        services = services[: self.num_services]
+        if next_leg_services is not None:
+            # Evaluate (and optionally filter) against the full raw list
+            # before truncating to num_services, so a catchable service
+            # further down isn't cut off by a low num_services setting.
+            services = self._filter_departed_trains(services)
+            self._tag_catchable(services, next_leg_services)
+            if self.only_catchable_services:
+                services = [s for s in services if s["catchable"]]
+            services = services[: self.num_services]
+        else:
+            # Limit to configured number of services
+            services = services[: self.num_services]
 
-        # Filter out trains that have already departed
-        services = self._filter_departed_trains(services)
+            # Filter out trains that have already departed
+            services = self._filter_departed_trains(services)
 
         # Calculate statistics
         on_time_count = sum(1 for s in services if s.get("status") == STATUS_ON_TIME)
@@ -576,6 +604,60 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             return STATUS_NORMAL
         return max(statuses, key=_STATUS_ORDER.index)
 
+    def _find_connecting_service(
+        self, arrival: str | None, candidates: list[dict[str, Any]]
+    ) -> tuple[dict[str, Any] | None, int | None]:
+        """Find the first candidate service catchable from an arrival time.
+
+        Args:
+            arrival: HH:MM arrival time at the interchange, or None
+            candidates: Non-cancelled outgoing services to search, in
+                departure order
+
+        Returns:
+            (service, buffer_minutes) for the first candidate departing at
+            least `min_connection_time` minutes after `arrival`, or
+            (None, None) if none qualify
+        """
+        if not arrival or not _TIME_FORMAT_RE.match(arrival):
+            return None, None
+        for service in candidates:
+            departure = service.get("expected_departure") or service.get(
+                "scheduled_departure"
+            )
+            buffer_minutes = self._minutes_between(arrival, departure)
+            if buffer_minutes is None:
+                continue
+            if buffer_minutes >= self.min_connection_time:
+                return service, buffer_minutes
+        return None, None
+
+    def _tag_catchable(
+        self,
+        services: list[dict[str, Any]],
+        next_leg_services: list[dict[str, Any]],
+    ) -> None:
+        """Tag each service in-place with whether its connection is catchable.
+
+        Matches against the next leg's full raw candidate pool rather than
+        its own (possibly truncated/filtered) displayed list, so a train
+        isn't excluded from consideration just because of display limits.
+
+        Args:
+            services: This leg's services, already filtered for departed
+                trains
+            next_leg_services: The following leg's raw services
+        """
+        candidates = self._filter_departed_trains(
+            [s for s in next_leg_services if not s.get("is_cancelled", False)]
+        )
+        for service in services:
+            arrival = service.get("estimated_arrival") or service.get(
+                "scheduled_arrival"
+            )
+            matched, _ = self._find_connecting_service(arrival, candidates)
+            service["catchable"] = matched is not None
+
     def _evaluate_connection(
         self, leg_from: dict[str, Any], leg_to: dict[str, Any]
     ) -> dict[str, Any]:
@@ -620,21 +702,14 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         base["arrival_time"] = arrival
 
         next_train_to = leg_to.get("next_train")
-        matched_service = None
-        matched_buffer = None
-        for service in leg_to.get("services", []):
-            if service.get("is_cancelled", False):
-                continue
-            departure = service.get("expected_departure") or service.get(
-                "scheduled_departure"
-            )
-            buffer_minutes = self._minutes_between(arrival, departure)
-            if buffer_minutes is None:
-                continue
-            if buffer_minutes >= self.min_connection_time:
-                matched_service = service
-                matched_buffer = buffer_minutes
-                break
+        candidates = [
+            service
+            for service in leg_to.get("services", [])
+            if not service.get("is_cancelled", False)
+        ]
+        matched_service, matched_buffer = self._find_connecting_service(
+            arrival, candidates
+        )
 
         if matched_service is None:
             base["feasible"] = False
@@ -710,8 +785,14 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Multi-leg journey: data is a list of raw responses, one per leg
         leg_results = [
-            self._parse_leg_data(leg, raw)
-            for leg, raw in zip(self.legs, data, strict=True)
+            self._parse_leg_data(
+                leg,
+                raw,
+                next_leg_services=(
+                    data[i + 1].get("services") if i + 1 < len(data) else None
+                ),
+            )
+            for i, (leg, raw) in enumerate(zip(self.legs, data, strict=True))
         ]
 
         all_services: list[dict[str, Any]] = []

--- a/custom_components/my_rail_commute/sensor.py
+++ b/custom_components/my_rail_commute/sensor.py
@@ -20,6 +20,7 @@ from .const import (
     ATTR_CANCELLATION_REASON,
     ATTR_CANCELLED_COUNT,
     ATTR_CANCELLED_COUNT_TODAY,
+    ATTR_CATCHABLE,
     ATTR_CONNECTIONS,
     ATTR_DAILY_BREAKDOWN,
     ATTR_DELAY_MINUTES,
@@ -126,6 +127,7 @@ def _build_all_trains_attribute(services: list[dict[str, Any]]) -> list[dict[str
             "estimated_arrival": service.get("estimated_arrival"),
             "scheduled_arrival": service.get("scheduled_arrival"),
             "destination": service.get("destination"),
+            ATTR_CATCHABLE: service.get("catchable"),
         }
 
         # Add optional fields if present
@@ -719,6 +721,7 @@ class TrainSensor(NationalRailCommuteEntity, SensorEntity):
             ATTR_CALLING_POINTS: train.get("calling_points", []),
             ATTR_SCHEDULED_ARRIVAL: train.get("scheduled_arrival"),
             ATTR_ESTIMATED_ARRIVAL: train.get("estimated_arrival"),
+            ATTR_CATCHABLE: train.get("catchable"),
             "last_updated": self.coordinator.data.get("last_updated"),
         }
 
@@ -935,6 +938,7 @@ class NextTrainSensor(NationalRailCommuteEntity, SensorEntity):
             ATTR_CALLING_POINTS: train.get("calling_points", []),
             ATTR_SCHEDULED_ARRIVAL: train.get("scheduled_arrival"),
             ATTR_ESTIMATED_ARRIVAL: train.get("estimated_arrival"),
+            ATTR_CATCHABLE: train.get("catchable"),
             "last_updated": self.coordinator.data.get("last_updated"),
         }
 

--- a/custom_components/my_rail_commute/strings.json
+++ b/custom_components/my_rail_commute/strings.json
@@ -37,7 +37,8 @@
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
           "departed_train_grace_period": "Departed Train Grace Period (minutes)",
-          "min_connection_time": "Minimum Connection Time (minutes)"
+          "min_connection_time": "Minimum Connection Time (minutes)",
+          "only_catchable_services": "Only Show Catchable Services (hide trains you can't make the connection for)"
         }
       },
       "return_journey": {
@@ -74,7 +75,8 @@
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
           "departed_train_grace_period": "Departed Train Grace Period (minutes)",
-          "min_connection_time": "Minimum Connection Time (minutes)"
+          "min_connection_time": "Minimum Connection Time (minutes)",
+          "only_catchable_services": "Only Show Catchable Services (hide trains you can't make the connection for)"
         }
       }
     },

--- a/custom_components/my_rail_commute/translations/en.json
+++ b/custom_components/my_rail_commute/translations/en.json
@@ -37,7 +37,8 @@
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
           "departed_train_grace_period": "Departed Train Grace Period (minutes)",
-          "min_connection_time": "Minimum Connection Time (minutes)"
+          "min_connection_time": "Minimum Connection Time (minutes)",
+          "only_catchable_services": "Only Show Catchable Services (hide trains you can't make the connection for)"
         }
       },
       "return_journey": {
@@ -74,7 +75,8 @@
           "minor_delay_threshold": "Minor Delays Threshold (minutes)",
           "night_updates": "Enable Night-Time Updates",
           "departed_train_grace_period": "Departed Train Grace Period (minutes)",
-          "min_connection_time": "Minimum Connection Time (minutes)"
+          "min_connection_time": "Minimum Connection Time (minutes)",
+          "only_catchable_services": "Only Show Catchable Services (hide trains you can't make the connection for)"
         }
       }
     },

--- a/tests/test_coordinator_multi_leg.py
+++ b/tests/test_coordinator_multi_leg.py
@@ -20,6 +20,7 @@ from custom_components.my_rail_commute.const import (
     CONF_MINOR_DELAY_THRESHOLD,
     CONF_NIGHT_UPDATES,
     CONF_NUM_SERVICES,
+    CONF_ONLY_CATCHABLE_SERVICES,
     CONF_ORIGIN,
     CONF_SEVERE_DELAY_THRESHOLD,
     CONF_TIME_WINDOW,
@@ -109,7 +110,10 @@ def _make_leg_response(origin_name: str, destination_name: str, services: list) 
 
 
 def _make_config(
-    legs: list[dict], min_connection_time: int = DEFAULT_MIN_CONNECTION_TIME
+    legs: list[dict],
+    min_connection_time: int = DEFAULT_MIN_CONNECTION_TIME,
+    num_services: int = 3,
+    only_catchable_services: bool = False,
 ) -> dict:
     """Build a multi-leg config dict."""
     return {
@@ -118,12 +122,13 @@ def _make_config(
         CONF_DESTINATION: legs[-1]["destination"],
         CONF_LEGS: legs,
         CONF_TIME_WINDOW: 60,
-        CONF_NUM_SERVICES: 3,
+        CONF_NUM_SERVICES: num_services,
         CONF_NIGHT_UPDATES: True,
         CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
         CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
         CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
         CONF_MIN_CONNECTION_TIME: min_connection_time,
+        CONF_ONLY_CATCHABLE_SERVICES: only_catchable_services,
     }
 
 
@@ -610,3 +615,233 @@ async def test_min_connection_time_config_affects_feasibility(
 
     assert data["connections"][0]["status"] == STATUS_CONNECTION_MISSED
     assert data["journey_feasible"] is False
+
+
+async def test_only_catchable_services_defaults_to_false(
+    hass: HomeAssistant,
+) -> None:
+    """The coordinator defaults only_catchable_services to False when absent."""
+    api = AsyncMock()
+    coordinator = NationalRailDataUpdateCoordinator(
+        hass,
+        api,
+        {
+            CONF_API_KEY: "test_key",
+            CONF_ORIGIN: "PAD",
+            CONF_DESTINATION: "RDG",
+            CONF_TIME_WINDOW: 60,
+            CONF_NUM_SERVICES: 3,
+            CONF_NIGHT_UPDATES: True,
+            CONF_SEVERE_DELAY_THRESHOLD: DEFAULT_SEVERE_DELAY_THRESHOLD,
+            CONF_MAJOR_DELAY_THRESHOLD: DEFAULT_MAJOR_DELAY_THRESHOLD,
+            CONF_MINOR_DELAY_THRESHOLD: DEFAULT_MINOR_DELAY_THRESHOLD,
+        },
+    )
+
+    assert coordinator.only_catchable_services is False
+
+
+async def test_non_last_leg_services_are_tagged_catchable(
+    hass: HomeAssistant,
+) -> None:
+    """Every non-final leg's services get a catchable flag, even when the
+    filter itself is off."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    catchable_service = _make_service("svc1")  # arrives 09:30
+    # Arrives at 09:50, after outgoing's only departure (09:45) — unreachable.
+    uncatchable_service = _make_service(
+        "svc1b", scheduled_departure="09:20", scheduled_arrival="09:50"
+    )
+    outgoing = _make_service("svc2", scheduled_departure="09:45")  # only reachable from svc1
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response(
+                "Paddington", "Reading", [catchable_service, uncatchable_service]
+            ),
+            _make_leg_response("Reading", "Oxford", [outgoing]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(
+            hass, api, _make_config(legs, num_services=2)
+        )
+        data = await coordinator._async_update_data()
+
+    leg1_services = {s["service_id"]: s["catchable"] for s in data["legs"][0]["services"]}
+    assert leg1_services == {"svc1": True, "svc1b": False}
+    # The last leg has nothing to connect onto, so it isn't tagged.
+    assert "catchable" not in data["legs"][1]["services"][0]
+
+
+async def test_only_catchable_services_filters_before_truncation(
+    hass: HomeAssistant,
+) -> None:
+    """Non-catchable services are dropped before num_services truncates the list,
+    so a catchable train further down isn't cut off by a low num_services."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    # Arrives 09:50 - after outgoing's only departure (09:45) - unreachable.
+    unreachable_first = _make_service(
+        "svc1a", scheduled_departure="08:55", scheduled_arrival="09:50"
+    )
+    # Arrives 09:30 - 15-minute buffer before outgoing's 09:45 departure.
+    reachable_second = _make_service(
+        "svc1b", scheduled_departure="09:00", scheduled_arrival="09:30"
+    )
+    outgoing = _make_service("svc2", scheduled_departure="09:45")
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response(
+                "Paddington", "Reading", [unreachable_first, reachable_second]
+            ),
+            _make_leg_response("Reading", "Oxford", [outgoing]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(
+            hass,
+            api,
+            _make_config(legs, num_services=1, only_catchable_services=True),
+        )
+        data = await coordinator._async_update_data()
+
+    leg1_services = data["legs"][0]["services"]
+    assert len(leg1_services) == 1
+    assert leg1_services[0]["service_id"] == "svc1b"
+    assert data["legs"][0]["next_train"]["service_id"] == "svc1b"
+
+
+async def test_only_catchable_services_disabled_keeps_uncatchable_services(
+    hass: HomeAssistant,
+) -> None:
+    """With the filter off, uncatchable services stay in the list (just tagged)."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    # Arrives 09:50 - after outgoing's only departure (09:45) - unreachable.
+    unreachable_first = _make_service(
+        "svc1a", scheduled_departure="08:55", scheduled_arrival="09:50"
+    )
+    reachable_second = _make_service(
+        "svc1b", scheduled_departure="09:00", scheduled_arrival="09:30"
+    )
+    outgoing = _make_service("svc2", scheduled_departure="09:45")
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response(
+                "Paddington", "Reading", [unreachable_first, reachable_second]
+            ),
+            _make_leg_response("Reading", "Oxford", [outgoing]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(
+            hass,
+            api,
+            _make_config(legs, num_services=1, only_catchable_services=False),
+        )
+        data = await coordinator._async_update_data()
+
+    leg1_services = data["legs"][0]["services"]
+    assert len(leg1_services) == 1
+    assert leg1_services[0]["service_id"] == "svc1a"
+    assert leg1_services[0]["catchable"] is False
+
+
+async def test_only_catchable_services_over_fetches_departure_rows(
+    hass: HomeAssistant,
+) -> None:
+    """Enabling the filter requests more rows per leg so there's a large
+    enough pool to filter down from and match connections against."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [_make_service("svc1")]),
+            _make_leg_response(
+                "Reading", "Oxford", [_make_service("svc2", scheduled_departure="09:45")]
+            ),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(
+            hass,
+            api,
+            _make_config(legs, num_services=3, only_catchable_services=True),
+        )
+        await coordinator._async_update_data()
+
+    for call in api.get_departure_board.call_args_list:
+        assert call.kwargs["num_rows"] == 20
+
+
+async def test_catchable_ignores_cancelled_and_departed_next_leg_services(
+    hass: HomeAssistant,
+) -> None:
+    """A cancelled or already-departed service on the next leg doesn't count
+    as a viable connection, even if its scheduled time would otherwise match."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    leg1_service = _make_service("svc1")  # arrives 09:30
+    cancelled_outgoing = _make_service(
+        "svc2a", scheduled_departure="09:45", status=STATUS_CANCELLED
+    )
+    departed_outgoing = _make_service("svc2b", scheduled_departure="07:00")
+    viable_outgoing = _make_service("svc2c", scheduled_departure="09:50")
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [leg1_service]),
+            _make_leg_response(
+                "Reading",
+                "Oxford",
+                [cancelled_outgoing, departed_outgoing, viable_outgoing],
+            ),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(
+            hass, api, _make_config(legs, num_services=1, only_catchable_services=True)
+        )
+        data = await coordinator._async_update_data()
+
+    assert data["legs"][0]["services"][0]["catchable"] is True
+    assert data["legs"][0]["services"][0]["service_id"] == "svc1"


### PR DESCRIPTION
Tags each non-final leg's services with whether their connection to the
next leg is catchable within min_connection_time, and adds an
only_catchable_services config option (multi-leg only) to filter down to
just those. Evaluation and filtering happen against the next leg's full
raw candidate pool before num_services truncates the list, and the
per-service matching logic is factored out of _evaluate_connection so
both share it.