### PR TITLE
Fix missed connections being masked by only_catchable_services

### DIFF
--- a/custom_components/my_rail_commute/api.py
+++ b/custom_components/my_rail_commute/api.py
@@ -510,7 +510,12 @@ class NationalRailAPI:
                 calling_points = [cp.get("locationName", "") for cp in filtered]
                 if dest_point:
                     scheduled_arrival = dest_point.get("st")
-                    estimated_arrival = dest_point.get("et")
+                    # "et" is "On time"/"Delayed"/"Cancelled" etc. when not a
+                    # real time (mirrors "etd" for departures) - only keep it
+                    # when it's an actual HH:MM, otherwise fall back to the
+                    # scheduled time below.
+                    et = dest_point.get("et")
+                    estimated_arrival = et if et and _TIME_FORMAT_RE.match(et) else None
 
             return {
                 "scheduled_departure": std,

--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -534,6 +534,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             # further down isn't cut off by a low num_services setting.
             services = self._filter_departed_trains(services)
             self._tag_catchable(services, next_leg_services)
+            # Keep the full tagged candidate pool (pre-only_catchable-filter)
+            # for connection-feasibility evaluation, so enabling the display
+            # filter can't turn a real "Missed Connection" into a falsely
+            # reassuring "Unknown" just because it emptied this leg's
+            # displayed service list.
+            connection_pool = services
             if self.only_catchable_services:
                 services = [s for s in services if s["catchable"]]
             services = services[: self.num_services]
@@ -543,6 +549,7 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Filter out trains that have already departed
             services = self._filter_departed_trains(services)
+            connection_pool = services
 
         # Calculate statistics
         on_time_count = sum(1 for s in services if s.get("status") == STATUS_ON_TIME)
@@ -562,6 +569,11 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             summary = self._build_all_departures_summary(
                 len(services), on_time_count, delayed_count, cancelled_count
             )
+        elif not services and connection_pool:
+            # only_catchable_services filtered out every real service on this
+            # leg — say so explicitly rather than the misleading "No trains
+            # found" (which implies no service is running at all).
+            summary = "No catchable connections"
         else:
             summary = self._build_summary(on_time_count, delayed_count, cancelled_count)
 
@@ -570,6 +582,15 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         for service in services:
             if not service.get("is_cancelled", False):
                 next_train = service
+                break
+
+        # Next train from the full (pre-only_catchable-filter) candidate
+        # pool, used for connection-feasibility evaluation so that filtering
+        # this leg's displayed services can't hide a real missed connection.
+        connection_next_train = None
+        for service in connection_pool:
+            if not service.get("is_cancelled", False):
+                connection_next_train = service
                 break
 
         return {
@@ -589,6 +610,8 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             "disruption_reasons": delay_info["disruption_reasons"],
             "summary": summary,
             "nrcc_messages": raw_data.get("nrcc_messages", []),
+            "connection_services": connection_pool,
+            "connection_next_train": connection_next_train,
         }
 
     def _combine_statuses(self, statuses: list[str]) -> str:
@@ -689,7 +712,16 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             "status": STATUS_CONNECTION_UNKNOWN,
         }
 
-        next_train_from = leg_from.get("next_train")
+        # Use the full (pre-only_catchable-filter) candidate pool rather than
+        # the possibly display-filtered "next_train"/"services", so enabling
+        # only_catchable_services can't turn a real missed connection into a
+        # falsely reassuring "Unknown" just because it emptied a leg's
+        # displayed service list. Falls back to the display fields when the
+        # connection-specific ones aren't present (e.g. hand-built dicts in
+        # tests, or a last leg with nothing to connect onto).
+        next_train_from = leg_from.get("connection_next_train") or leg_from.get(
+            "next_train"
+        )
         if not next_train_from:
             return base
 
@@ -701,10 +733,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         base["arrival_time"] = arrival
 
-        next_train_to = leg_to.get("next_train")
+        next_train_to = leg_to.get("connection_next_train") or leg_to.get("next_train")
         candidates = [
             service
-            for service in leg_to.get("services", [])
+            for service in (
+                leg_to.get("connection_services") or leg_to.get("services", [])
+            )
             if not service.get("is_cancelled", False)
         ]
         matched_service, matched_buffer = self._find_connecting_service(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -366,7 +366,33 @@ class TestParseService:
         result = api_client._parse_service(service_data, destination_crs="LBG")
 
         assert result["scheduled_arrival"] == "08:45"
-        assert result["estimated_arrival"] == "On time"
+        # "et" of "On time" isn't a real time - falls back to the scheduled
+        # arrival, same as how "etd" is handled for departures.
+        assert result["estimated_arrival"] == "08:45"
+
+    async def test_parse_service_uses_real_estimated_arrival_when_delayed(self, api_client):
+        """A genuinely delayed calling point's "et" (a real HH:MM) is kept,
+        not overridden by the scheduled time."""
+        service_data = {
+            "std": "08:32",
+            "etd": "08:40",
+            "platform": "3",
+            "operator": "Thameslink",
+            "serviceID": "service_ecr_lbg_delayed",
+            "destination": [{"locationName": "Cannon Street", "crs": "CST"}],
+            "subsequentCallingPoints": [
+                {
+                    "callingPoint": [
+                        {"locationName": "London Bridge", "crs": "LBG", "st": "08:45", "et": "08:53"},
+                    ]
+                }
+            ],
+        }
+
+        result = api_client._parse_service(service_data, destination_crs="LBG")
+
+        assert result["scheduled_arrival"] == "08:45"
+        assert result["estimated_arrival"] == "08:53"
 
     async def test_parse_service_falls_back_to_last_point_when_no_destination_crs(self, api_client):
         """Test that scheduled_arrival falls back to the last calling point when no destination_crs given."""

--- a/tests/test_coordinator_multi_leg.py
+++ b/tests/test_coordinator_multi_leg.py
@@ -845,3 +845,50 @@ async def test_catchable_ignores_cancelled_and_departed_next_leg_services(
 
     assert data["legs"][0]["services"][0]["catchable"] is True
     assert data["legs"][0]["services"][0]["service_id"] == "svc1"
+
+
+async def test_only_catchable_services_emptying_leg_still_reports_missed_connection(
+    hass: HomeAssistant,
+) -> None:
+    """When only_catchable_services filters a leg's services down to nothing,
+    the connection status must still reflect the real missed connection
+    instead of falling back to a falsely-reassuring Unknown, since the
+    feasibility check should use the full candidate pool, not the
+    display-filtered list."""
+    legs = [
+        {"origin": "PAD", "destination": "RDG"},
+        {"origin": "RDG", "destination": "OXF"},
+    ]
+    # Arrives 09:30; outgoing's only departure is 09:20 - before arrival, so
+    # this is genuinely uncatchable and gets filtered out of display.
+    leg1_service = _make_service("svc1")
+    outgoing = _make_service("svc2", scheduled_departure="09:20")
+
+    api = AsyncMock()
+    api.get_departure_board = AsyncMock(
+        side_effect=[
+            _make_leg_response("Paddington", "Reading", [leg1_service]),
+            _make_leg_response("Reading", "Oxford", [outgoing]),
+        ]
+    )
+
+    with patch(
+        "custom_components.my_rail_commute.coordinator.dt_util.now",
+        return_value=_TEST_TIME,
+    ):
+        coordinator = NationalRailDataUpdateCoordinator(
+            hass, api, _make_config(legs, only_catchable_services=True)
+        )
+        data = await coordinator._async_update_data()
+
+    # Displayed list is empty and says so explicitly, not "No trains found".
+    assert data["legs"][0]["services"] == []
+    assert data["legs"][0]["next_train"] is None
+    assert data["legs"][0]["summary"] == "No catchable connections"
+    assert data["legs"][0]["overall_status"] == STATUS_NORMAL
+
+    # But the connection evaluation still sees the real missed connection.
+    assert data["connections"][0]["status"] == STATUS_CONNECTION_MISSED
+    assert data["connections"][0]["feasible"] is False
+    assert data["journey_feasible"] is False
+    assert data["overall_status"] == STATUS_CRITICAL


### PR DESCRIPTION
When only_catchable_services filters a leg's displayed services down to
none (no train connects onto the next leg), connection evaluation was
reading the already-filtered next_train/services, so a genuinely missed
connection surfaced as Connection status "Unknown" instead of "Missed
Connection" — and the leg summary read "No trains found" even though
real trains exist, just none catchable.

Connection feasibility now evaluated from the full pre-filter candidate
pool (added as connection_services/connection_next_train on each leg),
independent of the only_catchable_services display filter. The leg
summary also now says "No catchable connections" in this case instead of
the misleading "No trains found".