### PR TITLE
Fix Delayed Connection false positives from normal timetable spacing

### DIFF
--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -628,7 +628,11 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         return max(statuses, key=_STATUS_ORDER.index)
 
     def _find_connecting_service(
-        self, arrival: str | None, candidates: list[dict[str, Any]]
+        self,
+        arrival: str | None,
+        candidates: list[dict[str, Any]],
+        *,
+        scheduled_only: bool = False,
     ) -> tuple[dict[str, Any] | None, int | None]:
         """Find the first candidate service catchable from an arrival time.
 
@@ -636,6 +640,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             arrival: HH:MM arrival time at the interchange, or None
             candidates: Non-cancelled outgoing services to search, in
                 departure order
+            scheduled_only: Ignore live running estimates and match purely
+                on timetabled times. Used to work out which service would
+                have formed the connection in a delay-free world, so actual
+                delays can be told apart from ordinary timetable spacing
+                (e.g. several closely-spaced local departures before the
+                one that's actually reachable).
 
         Returns:
             (service, buffer_minutes) for the first candidate departing at
@@ -645,9 +655,12 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         if not arrival or not _TIME_FORMAT_RE.match(arrival):
             return None, None
         for service in candidates:
-            departure = service.get("expected_departure") or service.get(
-                "scheduled_departure"
-            )
+            if scheduled_only:
+                departure = service.get("scheduled_departure")
+            else:
+                departure = service.get("expected_departure") or service.get(
+                    "scheduled_departure"
+                )
             buffer_minutes = self._minutes_between(arrival, departure)
             if buffer_minutes is None:
                 continue
@@ -733,7 +746,6 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
 
         base["arrival_time"] = arrival
 
-        next_train_to = leg_to.get("connection_next_train") or leg_to.get("next_train")
         candidates = [
             service
             for service in (
@@ -757,11 +769,24 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         base["buffer_minutes"] = matched_buffer
         base["feasible"] = True
 
-        is_next_train = (
-            next_train_to is not None
-            and matched_service.get("service_id") == next_train_to.get("service_id")
+        # Work out which service would have formed this connection in a
+        # delay-free world (timetabled arrival vs timetabled departures
+        # only). Several closely-spaced services departing too soon after
+        # arrival to catch is normal timetable spacing, not a delay - so
+        # only label the connection "Delayed" when an actual delay is what
+        # changed which service is being used, not just because it isn't
+        # the very next departure from the interchange.
+        scheduled_arrival = next_train_from.get("scheduled_arrival") or arrival
+        scheduled_matched, _ = self._find_connecting_service(
+            scheduled_arrival, candidates, scheduled_only=True
         )
-        if not is_next_train:
+        delayed = (
+            scheduled_matched is not None
+            and scheduled_matched.get("service_id") != matched_service.get(
+                "service_id"
+            )
+        )
+        if delayed:
             base["status"] = STATUS_CONNECTION_DELAYED
         elif matched_buffer >= self.min_connection_time + TIGHT_CONNECTION_MARGIN:
             base["status"] = STATUS_CONNECTION_OK

--- a/tests/test_coordinator_multi_leg.py
+++ b/tests/test_coordinator_multi_leg.py
@@ -469,16 +469,26 @@ async def test_evaluate_connection_missed_when_no_service_has_enough_buffer(
     assert conn["connecting_service_id"] is None
 
 
-async def test_evaluate_connection_delayed_when_a_later_train_is_needed(
+async def test_evaluate_connection_delayed_when_a_real_delay_forces_a_later_train(
     two_leg_coordinator: NationalRailDataUpdateCoordinator,
 ) -> None:
-    """Feasible only on a later train than the outgoing leg's own next train."""
-    leg_from = _make_leg_result("RDG", "Reading", _make_service("svc1"))
-    unreachable_next = _make_service("svc2a", scheduled_departure="09:20")
+    """A late-running incoming leg misses the service it would otherwise have
+    caught on schedule, and needs a later one instead."""
+    leg_from = _make_leg_result(
+        "RDG",
+        "Reading",
+        _make_service(
+            "svc1",
+            status=STATUS_DELAYED,
+            scheduled_arrival="09:20",
+            estimated_arrival="09:30",
+        ),
+    )
+    would_have_caught_on_schedule = _make_service("svc2a", scheduled_departure="09:30")
     reachable_later = _make_service("svc2b", scheduled_departure="09:50")
     leg_to = {
-        "services": [unreachable_next, reachable_later],
-        "next_train": unreachable_next,
+        "services": [would_have_caught_on_schedule, reachable_later],
+        "next_train": would_have_caught_on_schedule,
     }
 
     conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
@@ -486,6 +496,28 @@ async def test_evaluate_connection_delayed_when_a_later_train_is_needed(
     assert conn["status"] == STATUS_CONNECTION_DELAYED
     assert conn["feasible"] is True
     assert conn["connecting_service_id"] == "svc2b"
+
+
+async def test_evaluate_connection_not_delayed_when_earlier_trains_are_just_too_soon(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """Skipping several on-time-but-too-soon departures for a later,
+    comfortably-reachable on-time train is normal timetable spacing, not a
+    delay - even though it isn't the outgoing leg's literal next train."""
+    leg_from = _make_leg_result("RDG", "Reading", _make_service("svc1"))
+    too_soon_1 = _make_service("svc2a", scheduled_departure="09:31")
+    too_soon_2 = _make_service("svc2b", scheduled_departure="09:33")
+    comfortable = _make_service("svc2c", scheduled_departure="09:45")
+    leg_to = {
+        "services": [too_soon_1, too_soon_2, comfortable],
+        "next_train": too_soon_1,
+    }
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_OK
+    assert conn["feasible"] is True
+    assert conn["connecting_service_id"] == "svc2c"
 
 
 async def test_evaluate_connection_unknown_when_incoming_leg_has_no_next_train(


### PR DESCRIPTION
_evaluate_connection flagged any connection as "Delayed" whenever the
matched connecting service wasn't literally the outgoing leg's very
next departure. On interchanges with frequent local services, several
too-soon (but perfectly on-time) departures before the real connecting
train made this fire constantly with no actual delay involved.

Now compares against what would connect under fully scheduled times:
only mark a connection Delayed when a real delay changed which service
is being used, not just because earlier candidates were too tight.