### PR TITLE
Only flag connection as Delayed when the actual buffer is tight

### DIFF
--- a/custom_components/my_rail_commute/coordinator.py
+++ b/custom_components/my_rail_commute/coordinator.py
@@ -709,9 +709,15 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             leg_to: Parsed data for the leg departing from the interchange
 
         Returns:
-            Dict describing the connection: station, timings, buffer, and a
+            Dict describing the connection: station, timings, buffer, a
             status of Connection OK / Tight Connection / Delayed Connection /
-            Missed Connection / Unknown
+            Missed Connection / Unknown, and a human-readable
+            `connecting_summary` naming the train actually being caught.
+            "Delayed Connection" only fires when a live-running delay left
+            the matched train's buffer tight - a delay that reshuffled which
+            service gets caught but still leaves a comfortable buffer is
+            reported as "Connection OK", since the connection itself isn't
+            at risk.
         """
         base: dict[str, Any] = {
             "station": leg_from.get("destination"),
@@ -723,6 +729,7 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
             "min_required_minutes": self.min_connection_time,
             "feasible": None,
             "status": STATUS_CONNECTION_UNKNOWN,
+            "connecting_summary": None,
         }
 
         # Use the full (pre-only_catchable-filter) candidate pool rather than
@@ -760,6 +767,10 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         if matched_service is None:
             base["feasible"] = False
             base["status"] = STATUS_CONNECTION_MISSED
+            base["connecting_summary"] = (
+                f"No service leaves {base['station_name']} with enough time "
+                f"after the {arrival} arrival"
+            )
             return base
 
         base["connecting_departure"] = matched_service.get(
@@ -780,20 +791,63 @@ class NationalRailDataUpdateCoordinator(DataUpdateCoordinator):
         scheduled_matched, _ = self._find_connecting_service(
             scheduled_arrival, candidates, scheduled_only=True
         )
-        delayed = (
-            scheduled_matched is not None
-            and scheduled_matched.get("service_id") != matched_service.get(
-                "service_id"
-            )
+        delayed = scheduled_matched is not None and scheduled_matched.get(
+            "service_id"
+        ) != matched_service.get("service_id")
+        comfortable = (
+            matched_buffer >= self.min_connection_time + TIGHT_CONNECTION_MARGIN
         )
-        if delayed:
+        # A shifted match only matters if it left the connection tight - if
+        # the train actually being caught still has a comfortable buffer,
+        # calling it "Delayed" overstates the risk: minute-level noise
+        # between live and scheduled times (e.g. the interchange arrival
+        # estimate wobbling by a minute) can flip which service is "first
+        # catchable" without the connection ever being in jeopardy.
+        if delayed and not comfortable:
             base["status"] = STATUS_CONNECTION_DELAYED
-        elif matched_buffer >= self.min_connection_time + TIGHT_CONNECTION_MARGIN:
+        elif comfortable:
             base["status"] = STATUS_CONNECTION_OK
         else:
             base["status"] = STATUS_CONNECTION_TIGHT
 
+        base["connecting_summary"] = self._build_connection_summary(
+            base["status"], leg_to, matched_service, matched_buffer
+        )
+
         return base
+
+    @staticmethod
+    def _build_connection_summary(
+        status: str,
+        leg_to: dict[str, Any],
+        matched_service: dict[str, Any],
+        buffer_minutes: int,
+    ) -> str:
+        """Build a human-readable summary of which train the connection catches.
+
+        Args:
+            status: The connection's resolved status
+            leg_to: Parsed data for the leg departing from the interchange
+            matched_service: The outgoing service the connection resolves to
+            buffer_minutes: Minutes of spare time before that service leaves
+
+        Returns:
+            A short sentence naming the train and buffer, for display
+            alongside the terser status attributes
+        """
+        departure = matched_service.get("expected_departure") or matched_service.get(
+            "scheduled_departure"
+        )
+        destination_name = leg_to.get("destination_name") or leg_to.get("destination")
+        qualifier = (
+            " (delayed from an earlier train)"
+            if status == STATUS_CONNECTION_DELAYED
+            else ""
+        )
+        return (
+            f"Catching the {departure} to {destination_name} "
+            f"({buffer_minutes}m buffer){qualifier}"
+        )
 
     def _parse_data(
         self, data: dict[str, Any] | list[dict[str, Any]]

--- a/tests/test_coordinator_multi_leg.py
+++ b/tests/test_coordinator_multi_leg.py
@@ -469,11 +469,48 @@ async def test_evaluate_connection_missed_when_no_service_has_enough_buffer(
     assert conn["connecting_service_id"] is None
 
 
-async def test_evaluate_connection_delayed_when_a_real_delay_forces_a_later_train(
+async def test_evaluate_connection_delayed_when_a_real_delay_leaves_a_tight_buffer(
     two_leg_coordinator: NationalRailDataUpdateCoordinator,
 ) -> None:
     """A late-running incoming leg misses the service it would otherwise have
-    caught on schedule, and needs a later one instead."""
+    caught on schedule, and the later one it needs instead only leaves a
+    tight buffer - so the delay genuinely put the connection at risk."""
+    leg_from = _make_leg_result(
+        "RDG",
+        "Reading",
+        _make_service(
+            "svc1",
+            status=STATUS_DELAYED,
+            scheduled_arrival="09:20",
+            estimated_arrival="09:30",
+        ),
+    )
+    would_have_caught_on_schedule = _make_service("svc2a", scheduled_departure="09:30")
+    reachable_later = _make_service("svc2b", scheduled_departure="09:36")
+    leg_to = {
+        "services": [would_have_caught_on_schedule, reachable_later],
+        "next_train": would_have_caught_on_schedule,
+        "destination_name": "Oxford",
+    }
+
+    conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
+
+    assert conn["status"] == STATUS_CONNECTION_DELAYED
+    assert conn["feasible"] is True
+    assert conn["connecting_service_id"] == "svc2b"
+    assert conn["buffer_minutes"] == 6
+    assert conn["connecting_summary"] == (
+        "Catching the 09:36 to Oxford (6m buffer) (delayed from an earlier train)"
+    )
+
+
+async def test_evaluate_connection_ok_despite_real_delay_when_buffer_stays_comfortable(
+    two_leg_coordinator: NationalRailDataUpdateCoordinator,
+) -> None:
+    """A late-running incoming leg misses the service it would otherwise have
+    caught on schedule, but the later one it needs instead still leaves a
+    comfortable buffer - the connection itself was never at risk, so this
+    should read as OK rather than raising a false alarm."""
     leg_from = _make_leg_result(
         "RDG",
         "Reading",
@@ -489,13 +526,16 @@ async def test_evaluate_connection_delayed_when_a_real_delay_forces_a_later_trai
     leg_to = {
         "services": [would_have_caught_on_schedule, reachable_later],
         "next_train": would_have_caught_on_schedule,
+        "destination_name": "Oxford",
     }
 
     conn = two_leg_coordinator._evaluate_connection(leg_from, leg_to)
 
-    assert conn["status"] == STATUS_CONNECTION_DELAYED
+    assert conn["status"] == STATUS_CONNECTION_OK
     assert conn["feasible"] is True
     assert conn["connecting_service_id"] == "svc2b"
+    assert conn["buffer_minutes"] == 20
+    assert conn["connecting_summary"] == "Catching the 09:50 to Oxford (20m buffer)"
 
 
 async def test_evaluate_connection_not_delayed_when_earlier_trains_are_just_too_soon(


### PR DESCRIPTION
_evaluate_connection() previously labelled a connection "Delayed" any
time a live delay shifted which outgoing train would be caught, even
when the train actually caught still had a generous buffer. Minute-
level noise between an interchange's live and scheduled arrival
estimates could flip which service was "first catchable" without the
connection ever being at risk, producing a misleading "Delayed
Connection" state next to legs that were both individually on time.

Now the shift only escalates to Delayed when it left a tight buffer;
a shift that still lands on a comfortably-timed train reports OK.

Also add a `connecting_summary` attribute (e.g. "Catching the 18:20
to London Bridge (32m buffer)") so it's clear which specific train a
connection resolves to without having to reverse-engineer it from the
raw timing attributes.