### PR TITLE
Fix test_load_existing_data to mock current date

### DIFF
--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -58,7 +58,9 @@ async def test_load_existing_data():
                                          "total_delay_minutes": 10,
                                          "on_time_pct": 83.33, "avg_delay_minutes": 10.0}}}
     store = _make_store(load_return=existing)
-    await store.async_load()
+    with patch("custom_components.my_rail_commute.statistics.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value = date.fromisoformat("2026-05-17")
+        await store.async_load()
     assert "2026-05-17" in store._data
     assert store._data["2026-05-17"]["on_time_count"] == 5
 


### PR DESCRIPTION
async_load() prunes entries older than STATS_RETENTION_DAYS (90 days)
relative to the real current date. As time passed, the test's hardcoded
date (2026-05-17) fell outside that window and got pruned immediately
after loading, so the assertion failed. Mock dt_util.now() to the
fixture's own date, matching the pattern used by the other tests in
this file.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SZ75KUY2Jdzp11RcL1DS76